### PR TITLE
#292 error when compiling with MSVC 19

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -59,7 +59,12 @@ void QMarkdownHighlighter::setStyles(QVector<HighlightingStyle> &styles) {
 }
 
 
-#define STY(type, format) styles->append((HighlightingStyle){type, format})
+// The initial define causes an error with Visual Studio 2015:
+// "error C4576: a parenthesized type followed by an initializer list is
+// a non-standard explicit type conversion syntax"
+// The replacement works, probably also on other platforms (to be tested)
+//#define STY(type, format) styles->append((HighlightingStyle){type, format})
+#define STY(type, format) styles->append({type, format})
 
 void QMarkdownHighlighter::setDefaultStyles(int defaultFontSize) {
     QVector<HighlightingStyle> *styles = new QVector<HighlightingStyle>();


### PR DESCRIPTION
Compiling with MSVC19 leads to

error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax