### PR TITLE
Make list-autocompletion survive soft-wraps.

### DIFF
--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -816,7 +816,7 @@ bool QMarkdownTextEdit::handleReturnEntered() {
     QTextCursor c = this->textCursor();
     int position = c.position();
 
-    c.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
+    c.movePosition(QTextCursor::StartOfBlock, QTextCursor::KeepAnchor);
     QString currentLineText = c.selectedText();
 
     // if return is pressed and there is just a list symbol then we want to


### PR DESCRIPTION
When in a list and the content of a list-item is soft-wrapped (e.g. in
distraction-free mode), pressing `Enter` now inserts a new
list-character.

Refs: pbek/QOwnNotes#791