### PR TITLE
Consider comment lines with leading whitespaces

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -596,7 +596,7 @@ void MarkdownHighlighter::highlightCodeBlock(QString text) {
  */
 void MarkdownHighlighter::highlightCommentBlock(QString text) {
     bool highlight = false;
-	text = text.trimmed();
+    text = text.trimmed();
     QString startText = "<!--";
     QString endText = "-->";
 

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -596,7 +596,7 @@ void MarkdownHighlighter::highlightCodeBlock(QString text) {
  */
 void MarkdownHighlighter::highlightCommentBlock(QString text) {
     bool highlight = false;
-    text.trimmed();
+	text = text.trimmed();
     QString startText = "<!--";
     QString endText = "-->";
 


### PR DESCRIPTION
QString::trimmed() does not change to string itself, but returns a new string.