### PR TITLE
Use ctrl-enter to create a new line

### DIFF
--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -195,6 +195,13 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
             QTextCursor cursor = this->textCursor();
             cursor.insertText("  \n");
             return true;
+        } else if (keyEvent->key() == Qt::Key_Return &&
+                   keyEvent->modifiers().testFlag(Qt::ControlModifier)) {
+            QTextCursor cursor = this->textCursor();
+            cursor.movePosition(QTextCursor::EndOfLine);
+            cursor.insertText("\n");
+            setTextCursor(cursor);
+            return true;
         } else if ((keyEvent->key() == Qt::Key_Down) &&
                  keyEvent->modifiers().testFlag(Qt::ControlModifier) &&
                  keyEvent->modifiers().testFlag(Qt::AltModifier)) {


### PR DESCRIPTION
When the caret is in the middle of a line, use Ctrl-Enter to insert a new line and jump to it. This behavior is common in editors like Sublime Text, Visual Studio, etc.