### PR TITLE
Fixed inability to cut a blank line

### DIFF
--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -222,11 +222,14 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
                         // this is the paragraph separator
                         cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 1);
                     }
-                    if (keyEvent == QKeySequence::Cut) {
+                }
+                if (keyEvent == QKeySequence::Cut) {
+                    if (!cursor.atEnd() && text == "\n")
+                        cursor.deletePreviousChar();
+                    else
                         cursor.removeSelectedText();
-                        cursor.movePosition(QTextCursor::StartOfLine);
-                        setTextCursor(cursor);
-                    }
+                    cursor.movePosition(QTextCursor::StartOfLine);
+                    setTextCursor(cursor);
                 }
                 qApp->clipboard()->setText(text);
                 return true;


### PR DESCRIPTION
A blank line in the middle of the doc should be able to be cut, while a blank line at the end of the doc should be kept.