### PR TITLE
Minor syntax highlighter fixes

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -907,12 +907,6 @@ void MarkdownHighlighter::highlightSyntax(const QString &text)
     QTextCharFormat formatString = _formats[CodeString];
     QTextCharFormat formatNumLit = _formats[CodeNumLiteral];
     QTextCharFormat formatOther = _formats[CodeOther];
-    formatType.setBackground(f.background());
-    formatKeyword.setBackground(f.background());
-    formatComment.setBackground(f.background());
-    formatString.setBackground(f.background());
-    formatNumLit.setBackground(f.background());
-    formatOther.setBackground(f.background());
 
     for (int i=0; i< text.length(); i++) {
 
@@ -921,12 +915,10 @@ void MarkdownHighlighter::highlightSyntax(const QString &text)
             if (text[i] == QLatin1Char('/')) {
                 if((i+1) < text.length()){
                     if(text[i+1] == QLatin1Char('/')) {
-                        f.setForeground(Qt::darkGray);
                         setFormat(i, text.length(), formatComment);
                         return;
                     } else if(text[i+1] == QLatin1Char('*')) {
                         int next = text.indexOf(QLatin1String("*/"));
-                        f.setForeground(Qt::darkGray);
                         if (next == -1) {
                             setFormat(i, text.length(),  formatComment);
                             return;

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -935,7 +935,6 @@ void MarkdownHighlighter::highlightSyntax(const QString &text)
                         }
                     }
                 }
-                return;
             //integer literal
             } else if (text[i].isNumber()) {
                 if ( ((i+1) < text.length() && (i-1) > 0 ) &&

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -866,6 +866,7 @@ void MarkdownHighlighter::highlightSyntax(const QString &text)
     QStringList types,
                 keywords,
                 preproc;
+    QChar comment;
 
     switch (currentBlockState()) {
         case HighlighterState::CodeCpp :
@@ -879,6 +880,7 @@ void MarkdownHighlighter::highlightSyntax(const QString &text)
             break;
         case HighlighterState::CodeBash :
             loadShData(types, keywords, preproc);
+            comment = QLatin1Char('#');
             break;
         case HighlighterState::CodePHP :
             loadPHPData(types, keywords, preproc);
@@ -888,6 +890,7 @@ void MarkdownHighlighter::highlightSyntax(const QString &text)
             break;
         case HighlighterState::CodePython :
             loadPythonData(types, keywords, preproc);
+            comment = QLatin1Char('#');
             break;
     default:
         break;
@@ -935,6 +938,9 @@ void MarkdownHighlighter::highlightSyntax(const QString &text)
                         }
                     }
                 }
+            } else if (text[i] == comment) {
+                setFormat(i, text.length(), formatComment);
+                return;
             //integer literal
             } else if (text[i].isNumber()) {
                 if ( ((i+1) < text.length() && (i-1) > 0 ) &&


### PR DESCRIPTION
- Added support for #(hash) comments (py, bash)

Support for multiline comments still remains as I haven't figured it out completely yet. Seems like there is no straightforward way to do it.