### PR TITLE
add install target

### DIFF
--- a/qmarkdowntextedit-app.pro
+++ b/qmarkdowntextedit-app.pro
@@ -1,0 +1,14 @@
+TARGET   = QMarkdownTextedit
+TEMPLATE = app
+QT += core gui widgets
+
+SOURCES = main.cpp mainwindow.cpp
+HEADERS = mainwindow.h
+FORMS   = mainwindow.ui
+
+LIBS += -lQMarkdownTextedit -L$$OUT_PWD
+
+target.path = $$[QT_INSTALL_BINS]
+
+INSTALLS += target
+

--- a/qmarkdowntextedit-app.pro
+++ b/qmarkdowntextedit-app.pro
@@ -9,6 +9,8 @@ FORMS   = mainwindow.ui
 
 LIBS += -lQMarkdownTextedit -L$$OUT_PWD
 
+win32: LIBS +=  -L$$OUT_PWD/release -L$$OUT_PWD/debug
+
 target.path = $$[QT_INSTALL_BINS]
 
 INSTALLS += target

--- a/qmarkdowntextedit-app.pro
+++ b/qmarkdowntextedit-app.pro
@@ -1,6 +1,7 @@
 TARGET   = QMarkdownTextedit
 TEMPLATE = app
 QT += core gui widgets
+CONFIG += c++11
 
 SOURCES = main.cpp mainwindow.cpp
 HEADERS = mainwindow.h

--- a/qmarkdowntextedit-lib.pro
+++ b/qmarkdowntextedit-lib.pro
@@ -1,0 +1,17 @@
+TARGET = QMarkdownTextedit
+TEMPLATE = lib
+QT += core gui widgets
+
+include(qmarkdowntextedit.pri)
+
+TRANSLATIONS += trans/qmarkdowntextedit_de.ts
+
+target.path = $$[QT_INSTALL_LIBS]
+
+headers.files = $$HEADERS
+headers.path = $$[QT_INSTALL_PREFIX]/include/$$TARGET/
+
+license.files = LICENSE
+license.path = $$[QT_INSTALL_PREFIX]/share/licenses/$$TARGET/
+
+INSTALLS += target license headers

--- a/qmarkdowntextedit-lib.pro
+++ b/qmarkdowntextedit-lib.pro
@@ -1,6 +1,7 @@
 TARGET = QMarkdownTextedit
 TEMPLATE = lib
 QT += core gui widgets
+CONFIG += c++11
 
 include(qmarkdowntextedit.pri)
 

--- a/qmarkdowntextedit.pro
+++ b/qmarkdowntextedit.pro
@@ -2,3 +2,4 @@ TEMPLATE = subdirs
 SUBDIRS = app lib
 app.file = qmarkdowntextedit-app.pro
 lib.file = qmarkdowntextedit-lib.pro
+app.depends = lib

--- a/qmarkdowntextedit.pro
+++ b/qmarkdowntextedit.pro
@@ -1,23 +1,4 @@
-#-------------------------------------------------
-#
-# Project created by QtCreator 2016-01-11T16:56:21
-#
-#-------------------------------------------------
-
-QT       += core gui
-
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
-
-TARGET = QMarkdownTextedit
-TEMPLATE = app
-TRANSLATIONS = trans/qmarkdowntextedit_de.ts
-CONFIG += c++11
-
-SOURCES += main.cpp \
-    mainwindow.cpp \
-
-HEADERS  += mainwindow.h
-
-FORMS    += mainwindow.ui
-
-include(qmarkdowntextedit.pri)
+TEMPLATE = subdirs
+SUBDIRS = app lib
+app.file = qmarkdowntextedit-app.pro
+lib.file = qmarkdowntextedit-lib.pro


### PR DESCRIPTION
makes it easier to create packages for Linux distros.

normal usage as submodule using the .pri file should not be affected.