### PR TITLE
Re-implementation of num literal highlighter in CSH

### DIFF
--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -173,7 +173,7 @@ protected:
 
     QVector<HighlightingRule> _highlightingRulesPre;
     QVector<HighlightingRule> _highlightingRulesAfter;
-    static QHash<QString, HighlighterState> langStringToEnum;
+    static QHash<QString, HighlighterState> _langStringToEnum;
     QVector<QTextBlock> _dirtyTextBlocks;
     QHash<HighlighterState, QTextCharFormat> _formats;
     QTimer *_timer;


### PR DESCRIPTION
Complete rewrite of num literal highlighter that fixes all the issues and is much more sane, simple and fast unlike the previous hacky one.

For testing

```cpp
//should pass
int a = 10;
int a[10];
func(10, 10);
func(10,10);
func(10, 10, 19);
func(10,10,19);
func(10);
int a<10>;
int a{19};
int a{10, 19};
int a{10,19};
int a{10,19,21};
int a{10, 19, 21};
if (1 > 2)
if(1>2)
if (1>=2)
if(122 >= 2)
if (451 < 2)
if(561<2)
if(121<=2)
if(1 <= 2)
1>>2>>3
1 >> 2 >> 3;
0x10;
0x10
1000'000
123456789
//Should fail
123578912a
a123123
123a12a3
123abc123abc123
```