### PR TITLE
Markdown highlighter improvements

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -186,15 +186,6 @@ void MarkdownHighlighter::initHighlightingRules() {
 //    rule.state = HighlighterState::Table;
 //    _highlightingRulesPre.append(rule);
 
-    {
-        HighlightingRule rule(HighlighterState::MaskedSyntax);
-        // highlight strike through
-        rule.pattern = QRegularExpression(QStringLiteral(R"(\~{2}(.+?)\~{2})"));
-        rule.shouldContain[0] = QStringLiteral("~");
-        rule.capturingGroup = 1;
-        _highlightingRulesAfter.append(rule);
-    }
-
     // highlight urls
     {
         HighlightingRule rule(HighlighterState::Link);

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -228,6 +228,8 @@ protected:
 
     void highlightEmAndStrong(const QString &text, const int pos);
 
+    int highlightInlineComment(const QString &text, int pos);
+
     void highlightCodeFence(const QString &text);
 
     void highlightCodeBlock(const QString &text, const QString &opener = QStringLiteral("```"));

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -215,12 +215,26 @@ protected:
 
     void highlightMarkdown(const QString& text);
 
+    /******************************
+     *  BLOCK LEVEL FUNCTIONS
+     ******************************/
+
     void highlightHeadline(const QString& text);
 
     void highlightSubHeadline(const QString &text, HighlighterState state);
 
     void highlightAdditionalRules(const QVector<HighlightingRule> &rules,
                                   const QString& text);
+
+    void highlightFrontmatterBlock(const QString& text);
+
+    void highlightCommentBlock(QString text);
+
+    void highlightThematicBreak(const QString &text);
+
+    /******************************
+     *  INLINE FUNCTIONS
+     ******************************/
 
     void highlightInlineRules(const QString &text);
 
@@ -229,6 +243,10 @@ protected:
     void highlightEmAndStrong(const QString &text, const int pos);
 
     int highlightInlineComment(const QString &text, int pos);
+
+    /******************************
+     *  CODE HIGHLIGHTING FUNCTIONS
+     ******************************/
 
     void highlightIndentedCodeBlock(const QString &text);
 
@@ -251,10 +269,6 @@ protected:
     void xmlHighlighter(const QString &text);
 
     void taggerScriptHighlighter(const QString &text);
-
-    void highlightFrontmatterBlock(const QString& text);
-
-    void highlightCommentBlock(QString text);
 
     void addDirtyBlock(const QTextBlock& block);
 

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -230,6 +230,8 @@ protected:
 
     int highlightInlineComment(const QString &text, int pos);
 
+    void highlightIndentedCodeBlock(const QString &text);
+
     void highlightCodeFence(const QString &text);
 
     void highlightCodeBlock(const QString &text, const QString &opener = QStringLiteral("```"));


### PR DESCRIPTION
pbek/QOwnNotes#1598

- Fixed comment block highlighting when `<!--` is not at start of the block
- Rewritten inline comment highlighter
- Rewritten indented code highlighter (more commonmark compliant)
  - Indented code has now basic syntax highlighting
- Rewritten thematic breaks highlighting