### PR TITLE
Add missing qownlanguagedata.cpp to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,16 +22,13 @@ qt5_add_resources(RESOURCE_ADDED ${RESOURCE_FILES})
 
 set(SOURCE_FILES
     markdownhighlighter.cpp
-    markdownhighlighter.h
     main.cpp
     mainwindow.cpp
-    mainwindow.h
     mainwindow.ui
     qmarkdowntextedit.cpp
-    qmarkdowntextedit.h
+    qownlanguagedata.cpp
     qplaintexteditsearchwidget.ui
     qplaintexteditsearchwidget.cpp
-    qplaintexteditsearchwidget.h
     )
 
 add_executable(qmarkdowntextedit ${SOURCE_FILES} ${RESOURCE_ADDED})


### PR DESCRIPTION
CMakeLists.txt had no `qownlanguagedata.cpp` resulting in failing build. 
Also .h files are removed from CMakeLists.txt because they don't need to be compiled.