### PR TITLE
Rewrite markdown lists parsing

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -117,7 +117,7 @@ void MarkdownHighlighter::initHighlightingRules() {
         HighlightingRule rule(HighlighterState::MaskedSyntax);
         rule.pattern = QRegularExpression(QStringLiteral(R"(^\[.+?\]: \w+://.+$)"));
         rule.shouldContain = QStringLiteral("://");
-        _highlightingRulesPre.append(rule);
+        _highlightingRules.append(rule);
     }
 
     // highlight block quotes
@@ -128,7 +128,7 @@ void MarkdownHighlighter::initHighlightingRules() {
                         HighlightingOption::FullyHighlightedBlockQuote) ?
                         QStringLiteral("^\\s*(>\\s*.+)") : QStringLiteral("^\\s*(>\\s*)+"));
         rule.shouldContain = QStringLiteral("> ");
-        _highlightingRulesPre.append(rule);
+        _highlightingRules.append(rule);
     }
 
     // highlight tables without starting |
@@ -146,43 +146,43 @@ void MarkdownHighlighter::initHighlightingRules() {
         rule.pattern = QRegularExpression(QStringLiteral(R"(\b\w+?:\/\/[^\s>]+)"));
         rule.capturingGroup = 0;
         rule.shouldContain = QStringLiteral("://");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
 
         // highlight urls with <> but without any . in it
         rule.pattern = QRegularExpression(QStringLiteral(R"(<(\w+?:\/\/[^\s]+)>)"));
         rule.capturingGroup = 1;
         rule.shouldContain = QStringLiteral("://");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
 
         // highlight links with <> that have a .in it
         //    rule.pattern = QRegularExpression("<(.+?:\\/\\/.+?)>");
         rule.pattern = QRegularExpression(QStringLiteral("<([^\\s`][^`]*?\\.[^`]*?[^\\s`])>"));
         rule.capturingGroup = 1;
         rule.shouldContain = QStringLiteral("<");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
 
         // highlight urls with title
         //    rule.pattern = QRegularExpression("\\[(.+?)\\]\\(.+?://.+?\\)");
         //    rule.pattern = QRegularExpression("\\[(.+?)\\]\\(.+\\)\\B");
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[([^\[\]]+)\]\((\S+|.+?)\)\B)"));
         rule.shouldContain = QStringLiteral("](");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
 
         // highlight urls with empty title
         //    rule.pattern = QRegularExpression("\\[\\]\\((.+?://.+?)\\)");
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[\]\((.+?)\))"));
         rule.shouldContain = QStringLiteral("[](");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
 
         // highlight email links
         rule.pattern = QRegularExpression(QStringLiteral("<(.+?@.+?)>"));
         rule.shouldContain = QStringLiteral("@");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
 
         // highlight reference links
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[(.+?)\]\[.+?\])"));
         rule.shouldContain = QStringLiteral("[");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
     }
 
     // Images
@@ -192,12 +192,12 @@ void MarkdownHighlighter::initHighlightingRules() {
         rule.pattern = QRegularExpression(QStringLiteral(R"(!\[(.+?)\]\(.+?\))"));
         rule.shouldContain = QStringLiteral("![");
         rule.capturingGroup = 1;
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
 
         // highlight images without text
         rule.pattern = QRegularExpression(QStringLiteral(R"(!\[\]\((.+?)\))"));
         rule.shouldContain = QStringLiteral("![]");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
     }
 
     // highlight images links
@@ -206,12 +206,12 @@ void MarkdownHighlighter::initHighlightingRules() {
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[!\[(.+?)\]\(.+?\)\]\(.+?\))"));
         rule.shouldContain = QStringLiteral("[![");
         rule.capturingGroup = 1;
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
 
         // highlight images links without text
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[!\[\]\(.+?\)\]\((.+?)\))"));
         rule.shouldContain = QStringLiteral("[![](");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
     }
 
     // highlight trailing spaces
@@ -220,7 +220,7 @@ void MarkdownHighlighter::initHighlightingRules() {
         rule.pattern = QRegularExpression(QStringLiteral("( +)$"));
         rule.shouldContain = QString(" \0"); //waqar144: dont use QStringLiteral here.
         rule.capturingGroup = 1;
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
     }
 
     // highlight inline comments
@@ -229,7 +229,7 @@ void MarkdownHighlighter::initHighlightingRules() {
         HighlightingRule rule(HighlighterState::Comment);
         rule.pattern = QRegularExpression(QStringLiteral(R"(^\[.+?\]: # \(.+?\)$)"));
         rule.shouldContain = QStringLiteral("]: # (");
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
     }
 
     // highlight tables with starting |
@@ -237,7 +237,7 @@ void MarkdownHighlighter::initHighlightingRules() {
         HighlightingRule rule(HighlighterState::Table);
         rule.shouldContain = QStringLiteral("|");
         rule.pattern = QRegularExpression(QStringLiteral("^\\|.+?\\|$"));
-        _highlightingRulesAfter.append(rule);
+        _highlightingRules.append(rule);
     }
 }
 
@@ -468,14 +468,12 @@ void MarkdownHighlighter::highlightMarkdown(const QString& text) {
                             text.startsWith(QLatin1String("~~~"));
 
     if (!text.isEmpty() && !isBlockCodeBlock) {
-        highlightAdditionalRules(_highlightingRulesPre, text);
+        highlightAdditionalRules(_highlightingRules, text);
 
         highlightThematicBreak(text);
 
         // needs to be called after the horizontal ruler highlighting
         highlightHeadline(text);
-
-        highlightAdditionalRules(_highlightingRulesAfter, text);
 
         highlightIndentedCodeBlock(text);
 
@@ -1838,8 +1836,8 @@ void MarkdownHighlighter::setHeadingStyles(MarkdownHighlighter::HighlighterState
  *
  * @param text
  */
-void MarkdownHighlighter::highlightAdditionalRules(
-        const QVector<HighlightingRule> &rules, const QString& text) {
+void MarkdownHighlighter::highlightAdditionalRules(const QVector<HighlightingRule> &rules,
+                                                   const QString& text) {
     const QTextCharFormat &maskedFormat = _formats[HighlighterState::MaskedSyntax];
 
     for(const HighlightingRule &rule : rules) {

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -2103,7 +2103,7 @@ void balancePairs(QVector<Delimiter> &delims);
 /**
  * @brief highlights Em/Strong in text editor
  */
-void MarkdownHighlighter::highlightEmAndStrong(const QString &text, const int pos){
+void MarkdownHighlighter::highlightEmAndStrong(const QString &text, const int pos) {
     //1. collect all em/strong delimiters
     QVector<Delimiter> delims;
     for (int i = pos; i < text.length(); ++i) {
@@ -2117,7 +2117,7 @@ void MarkdownHighlighter::highlightEmAndStrong(const QString &text, const int po
     balancePairs(delims);
 
     //start,length -> helper for applying masking later
-    QVector<QPair<const int, const int>> masked;
+    QVector<QPair<int, int>> masked;
     masked.reserve(delims.size() / 2);
 
     //3. final processing & highlighting
@@ -2156,11 +2156,11 @@ void MarkdownHighlighter::highlightEmAndStrong(const QString &text, const int po
                 else
                     fmt.setFontWeight(QFont::Bold);
                 setFormat(k, 1, fmt);
-                k++;
+                ++k;
             }
             masked.append({startDelim.pos - 1, 2});
             masked.append({endDelim.pos, 2});
-            i--;
+            --i;
         } else {
 //            qDebug () << "Em: " << startDelim.pos << endDelim.pos;
 //            qDebug () << "Em Txt: " << text.mid(startDelim.pos, endDelim.pos - startDelim.pos);
@@ -2180,7 +2180,7 @@ void MarkdownHighlighter::highlightEmAndStrong(const QString &text, const int po
                 else
                     fmt.setFontItalic(true);
                 setFormat(k, 1, fmt);
-                k++;
+                ++k;
             }
             masked.append({startDelim.pos, 1});
             masked.append({endDelim.pos, 1});
@@ -2204,8 +2204,7 @@ void MarkdownHighlighter::highlightEmAndStrong(const QString &text, const int po
  * @param pos
  * @return position after the comment
  */
-int MarkdownHighlighter::highlightInlineComment(const QString &text, int pos)
-{
+int MarkdownHighlighter::highlightInlineComment(const QString &text, int pos) {
     const int start = pos;
     pos += 4;
 

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -518,32 +518,29 @@ void MarkdownHighlighter::highlightHeadline(const QString& text) {
         return;
     bool headingFound = false;
     if (spacesOffset == 1)
-        headingFound = text.at(1) == QChar('#');
+        headingFound = text.at(1) == QLatin1Char('#');
     else if (spacesOffset == 2)
-        headingFound = text.at(2) == QChar('#');
+        headingFound = text.at(2) == QLatin1Char('#');
     else if (spacesOffset == 3)
-        headingFound = text.at(3) == QChar('#');
+        headingFound = text.at(3) == QLatin1Char('#');
     else
-        headingFound = text.at(0) == QChar('#');
+        headingFound = text.at(0) == QLatin1Char('#');
 
     if (headingFound) {
         int headingLevel = 0;
         int i = spacesOffset;
         if (i >= text.length())
             return;
-        while(i < text.length() && text.at(i) == QChar('#') && i < (spacesOffset + 6))
+        while(i < text.length() && text.at(i) == QLatin1Char('#') && i < (spacesOffset + 6))
             ++i;
 
-        if (i < text.length() && text.at(i) == QChar(' '))
+        if (i < text.length() && text.at(i) == QLatin1Char(' '))
             headingLevel = i - spacesOffset;
 
         if (headingLevel > 0) {
             const auto state = HighlighterState(HighlighterState::H1 + headingLevel - 1);
 
             setFormat(0, text.length(), _formats[state]);
-
-            // set a margin for the current block
-            setCurrentBlockMargin(state);
 
             setCurrentBlockState(state);
             return;
@@ -586,7 +583,6 @@ void MarkdownHighlighter::highlightHeadline(const QString& text) {
         if (nextHasEqualChars) {
             setFormat(0, text.length(), _formats[HighlighterState::H1]);
             setCurrentBlockState(HighlighterState::H1);
-            currentBlock().setUserState(HighlighterState::H1);
         }
     }
     else if (nextBlockText.at(nextSpaces) == QLatin1Char('-')) {
@@ -594,7 +590,6 @@ void MarkdownHighlighter::highlightHeadline(const QString& text) {
         if (nextHasMinusChars) {
             setFormat(0, text.length(), _formats[HighlighterState::H2]);
             setCurrentBlockState(HighlighterState::H2);
-            currentBlock().setUserState(HighlighterState::H2);
         }
     }
 }
@@ -618,9 +613,6 @@ void MarkdownHighlighter::highlightSubHeadline(const QString &text, HighlighterS
         setFormat(0, text.length(), currentMaskedFormat);
         setCurrentBlockState(HeadlineEnd);
 
-        // set a margin for the current block
-        setCurrentBlockMargin(state);
-
         // we want to re-highlight the previous block
         // this must not done directly, but with a queue, otherwise it
         // will crash
@@ -632,50 +624,6 @@ void MarkdownHighlighter::highlightSubHeadline(const QString &text, HighlighterS
             previousBlock.setUserState(state);
         }
     }
-}
-
-
-/**
- * Sets a margin for the current block
- *
- * @param state
- */
-void MarkdownHighlighter::setCurrentBlockMargin(
-        MarkdownHighlighter::HighlighterState state) {
-    // this is currently disabled because it causes multiple problems:
-    // - it prevents "undo" in headlines
-    //   https://github.com/pbek/QOwnNotes/issues/520
-    // - invisible lines at the end of a note
-    //   https://github.com/pbek/QOwnNotes/issues/667
-    // - a crash when reaching the invisible lines when the current line is
-    //   highlighted
-    //   https://github.com/pbek/QOwnNotes/issues/701
-    return;
-
-    qreal margin;
-
-    switch (state) {
-        case HighlighterState::H1:
-            margin = 5;
-            break;
-        case HighlighterState::H2:
-        case HighlighterState::H3:
-        case HighlighterState::H4:
-        case HighlighterState::H5:
-        case HighlighterState::H6:
-            margin = 3;
-            break;
-        default:
-            return;
-    }
-
-    QTextBlockFormat blockFormat = currentBlock().blockFormat();
-    blockFormat.setTopMargin(2);
-    blockFormat.setBottomMargin(margin);
-
-    // this prevents "undo" in headlines!
-    QTextCursor* myCursor = new QTextCursor(currentBlock());
-    myCursor->setBlockFormat(blockFormat);
 }
 
 /**

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -116,7 +116,7 @@ void MarkdownHighlighter::initHighlightingRules() {
     {
         HighlightingRule rule(HighlighterState::MaskedSyntax);
         rule.pattern = QRegularExpression(QStringLiteral(R"(^\[.+?\]: \w+://.+$)"));
-        rule.shouldContain[0] = QStringLiteral("://");
+        rule.shouldContain = QStringLiteral("://");
         _highlightingRulesPre.append(rule);
     }
 
@@ -127,7 +127,7 @@ void MarkdownHighlighter::initHighlightingRules() {
                     _highlightingOptions.testFlag(
                         HighlightingOption::FullyHighlightedBlockQuote) ?
                         QStringLiteral("^\\s*(>\\s*.+)") : QStringLiteral("^\\s*(>\\s*)+"));
-        rule.shouldContain[0] = QStringLiteral("> ");
+        rule.shouldContain = QStringLiteral("> ");
         _highlightingRulesPre.append(rule);
     }
 
@@ -145,43 +145,43 @@ void MarkdownHighlighter::initHighlightingRules() {
         // highlight urls without any other markup
         rule.pattern = QRegularExpression(QStringLiteral(R"(\b\w+?:\/\/[^\s>]+)"));
         rule.capturingGroup = 0;
-        rule.shouldContain[0] = QStringLiteral("://");
+        rule.shouldContain = QStringLiteral("://");
         _highlightingRulesAfter.append(rule);
 
         // highlight urls with <> but without any . in it
         rule.pattern = QRegularExpression(QStringLiteral(R"(<(\w+?:\/\/[^\s]+)>)"));
         rule.capturingGroup = 1;
-        rule.shouldContain[0] = QStringLiteral("://");
+        rule.shouldContain = QStringLiteral("://");
         _highlightingRulesAfter.append(rule);
 
         // highlight links with <> that have a .in it
         //    rule.pattern = QRegularExpression("<(.+?:\\/\\/.+?)>");
         rule.pattern = QRegularExpression(QStringLiteral("<([^\\s`][^`]*?\\.[^`]*?[^\\s`])>"));
         rule.capturingGroup = 1;
-        rule.shouldContain[0] = QStringLiteral("<");
+        rule.shouldContain = QStringLiteral("<");
         _highlightingRulesAfter.append(rule);
 
         // highlight urls with title
         //    rule.pattern = QRegularExpression("\\[(.+?)\\]\\(.+?://.+?\\)");
         //    rule.pattern = QRegularExpression("\\[(.+?)\\]\\(.+\\)\\B");
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[([^\[\]]+)\]\((\S+|.+?)\)\B)"));
-        rule.shouldContain[0] = QStringLiteral("](");
+        rule.shouldContain = QStringLiteral("](");
         _highlightingRulesAfter.append(rule);
 
         // highlight urls with empty title
         //    rule.pattern = QRegularExpression("\\[\\]\\((.+?://.+?)\\)");
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[\]\((.+?)\))"));
-        rule.shouldContain[0] = QStringLiteral("[](");
+        rule.shouldContain = QStringLiteral("[](");
         _highlightingRulesAfter.append(rule);
 
         // highlight email links
         rule.pattern = QRegularExpression(QStringLiteral("<(.+?@.+?)>"));
-        rule.shouldContain[0] = QStringLiteral("@");
+        rule.shouldContain = QStringLiteral("@");
         _highlightingRulesAfter.append(rule);
 
         // highlight reference links
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[(.+?)\]\[.+?\])"));
-        rule.shouldContain[0] = QStringLiteral("[");
+        rule.shouldContain = QStringLiteral("[");
         _highlightingRulesAfter.append(rule);
     }
 
@@ -190,13 +190,13 @@ void MarkdownHighlighter::initHighlightingRules() {
         // highlight images with text
         HighlightingRule rule(HighlighterState::Image);
         rule.pattern = QRegularExpression(QStringLiteral(R"(!\[(.+?)\]\(.+?\))"));
-        rule.shouldContain[0] = QStringLiteral("![");
+        rule.shouldContain = QStringLiteral("![");
         rule.capturingGroup = 1;
         _highlightingRulesAfter.append(rule);
 
         // highlight images without text
         rule.pattern = QRegularExpression(QStringLiteral(R"(!\[\]\((.+?)\))"));
-        rule.shouldContain[0] = QStringLiteral("![]");
+        rule.shouldContain = QStringLiteral("![]");
         _highlightingRulesAfter.append(rule);
     }
 
@@ -204,13 +204,13 @@ void MarkdownHighlighter::initHighlightingRules() {
     {
         HighlightingRule rule(HighlighterState::Link);
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[!\[(.+?)\]\(.+?\)\]\(.+?\))"));
-        rule.shouldContain[0] = QStringLiteral("[![");
+        rule.shouldContain = QStringLiteral("[![");
         rule.capturingGroup = 1;
         _highlightingRulesAfter.append(rule);
 
         // highlight images links without text
         rule.pattern = QRegularExpression(QStringLiteral(R"(\[!\[\]\(.+?\)\]\((.+?)\))"));
-        rule.shouldContain[0] = QStringLiteral("[![](");
+        rule.shouldContain = QStringLiteral("[![](");
         _highlightingRulesAfter.append(rule);
     }
 
@@ -218,7 +218,7 @@ void MarkdownHighlighter::initHighlightingRules() {
     {
         HighlightingRule rule(HighlighterState::TrailingSpace);
         rule.pattern = QRegularExpression(QStringLiteral("( +)$"));
-        rule.shouldContain[0] = QString(" \0"); //waqar144: dont use QStringLiteral here.
+        rule.shouldContain = QString(" \0"); //waqar144: dont use QStringLiteral here.
         rule.capturingGroup = 1;
         _highlightingRulesAfter.append(rule);
     }
@@ -228,14 +228,14 @@ void MarkdownHighlighter::initHighlightingRules() {
         // highlight comments for Rmarkdown for academic papers
         HighlightingRule rule(HighlighterState::Comment);
         rule.pattern = QRegularExpression(QStringLiteral(R"(^\[.+?\]: # \(.+?\)$)"));
-        rule.shouldContain[0] = QStringLiteral("]: # (");
+        rule.shouldContain = QStringLiteral("]: # (");
         _highlightingRulesAfter.append(rule);
     }
 
     // highlight tables with starting |
     {
         HighlightingRule rule(HighlighterState::Table);
-        rule.shouldContain[0] = QStringLiteral("|");
+        rule.shouldContain = QStringLiteral("|");
         rule.pattern = QRegularExpression(QStringLiteral("^\\|.+?\\|$"));
         _highlightingRulesAfter.append(rule);
     }
@@ -1850,16 +1850,7 @@ void MarkdownHighlighter::highlightAdditionalRules(
             continue;
         }
 
-        bool contains = false;
-        if (text.contains(rule.shouldContain[0])) {
-            contains = true;
-        }
-        if ( (!contains && !rule.shouldContain[1].isEmpty()) && text.contains(rule.shouldContain[1])){
-            contains = true;
-        }
-        if ( (!contains && !rule.shouldContain[2].isEmpty()) && text.contains(rule.shouldContain[2])){
-            contains = true;
-        }
+        const bool contains = text.contains(rule.shouldContain) ? true : false;
         if (!contains)
             continue;
 
@@ -1926,7 +1917,7 @@ void MarkdownHighlighter::highlightInlineRules(const QString &text)
                    text.at(i + 1) == QLatin1Char('!') && text.at(i + 2) == QLatin1Char('-') &&
                    text.at(i + 3) == QLatin1Char('-')
                    ) {
-            highlightInlineComment(text, i);
+            i = highlightInlineComment(text, i);
         } else if (!isEmStrongDone &&
                  (text.at(i) == QLatin1Char('*') || text.at(i) == QLatin1Char('_'))) {
             highlightEmAndStrong(text, i);

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -41,7 +41,7 @@ public:
                         HighlightingOptions highlightingOptions =
                         HighlightingOption::None);
 
-    inline QColor codeBlockBackgroundColor() const {
+    static inline QColor codeBlockBackgroundColor() {
         const QBrush brush = _formats[CodeBlock].background();
 
         if (!brush.isOpaque()) {
@@ -51,10 +51,10 @@ public:
         return brush.color();
     }
 
-   inline bool isOctal(const char c) {
+   static inline bool isOctal(const char c) {
        return (c >= '0' && c <= '7');
    }
-   inline bool isHex(const char c) {
+   static inline bool isHex(const char c) {
        return (c >= '0' && c <= '9') ||
               (c >= 'a' && c <= 'f') ||
               (c >= 'A' && c <= 'F');
@@ -177,8 +177,8 @@ public:
 //        CodeBlockEnd
 //    };
 
-    void setTextFormats(QHash<HighlighterState, QTextCharFormat> formats);
-    void setTextFormat(HighlighterState state, QTextCharFormat format);
+    static void setTextFormats(QHash<HighlighterState, QTextCharFormat> formats);
+    static void setTextFormat(HighlighterState state, QTextCharFormat format);
     void clearDirtyBlocks();
     void setHighlightingOptions(const HighlightingOptions options);
     void initHighlightingRules();
@@ -194,7 +194,6 @@ protected:
         HighlightingRule() = default;
 
         QRegularExpression pattern;
-        HighlighterState state = NoState;
         /*
          * waqar144:
          * Dear programmer,
@@ -205,6 +204,7 @@ protected:
          * Dated: 5-Jan-2020
          */
         QString shouldContain[3];
+        HighlighterState state = NoState;
         uint8_t capturingGroup = 0;
         uint8_t maskedGroup = 0;
         bool useStateAsCurrentBlockState = false;
@@ -213,7 +213,9 @@ protected:
 
     void highlightBlock(const QString &text) Q_DECL_OVERRIDE;
 
-    void initTextFormats(int defaultFontSize = 12);
+    static void initTextFormats(int defaultFontSize = 12);
+
+    static void initCodeLangs();
 
     void highlightMarkdown(const QString& text);
 
@@ -230,7 +232,7 @@ protected:
 
     void highlightFrontmatterBlock(const QString& text);
 
-    void highlightCommentBlock(QString text);
+    void highlightCommentBlock(const QString &text);
 
     void highlightThematicBreak(const QString &text);
 
@@ -280,13 +282,11 @@ protected:
                      const QRegularExpressionMatch &match,
                      const int capturedGroup);
 
-    static void initCodeLangs();
-
     QVector<HighlightingRule> _highlightingRulesPre;
     QVector<HighlightingRule> _highlightingRulesAfter;
     static QHash<QString, HighlighterState> _langStringToEnum;
     QVector<QTextBlock> _dirtyTextBlocks;
-    QHash<HighlighterState, QTextCharFormat> _formats;
+    static QHash<HighlighterState, QTextCharFormat> _formats;
     QTimer *_timer;
     bool _highlightingFinished;
     HighlightingOptions _highlightingOptions;

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -275,11 +275,10 @@ protected:
                      const QRegularExpressionMatch &match,
                      const int capturedGroup);
 
-    QVector<HighlightingRule> _highlightingRulesPre;
-    QVector<HighlightingRule> _highlightingRulesAfter;
+    QVector<HighlightingRule> _highlightingRules;
+    static QHash<HighlighterState, QTextCharFormat> _formats;
     static QHash<QString, HighlighterState> _langStringToEnum;
     QVector<QTextBlock> _dirtyTextBlocks;
-    static QHash<HighlighterState, QTextCharFormat> _formats;
     QTimer *_timer;
     bool _highlightingFinished;
     HighlightingOptions _highlightingOptions;

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -51,22 +51,22 @@ public:
         return brush.color();
     }
 
-   static inline bool isOctal(const char c) {
+   static constexpr inline bool isOctal(const char c) {
        return (c >= '0' && c <= '7');
    }
-   static inline bool isHex(const char c) {
+   static constexpr inline bool isHex(const char c) {
        return (c >= '0' && c <= '9') ||
               (c >= 'a' && c <= 'f') ||
               (c >= 'A' && c <= 'F');
    }
-   static inline bool isCodeBlock(const int state) {
+   static constexpr inline bool isCodeBlock(const int state) {
       return state == MarkdownHighlighter::CodeBlock ||
              state == MarkdownHighlighter::CodeBlockTilde ||
              state == MarkdownHighlighter::CodeBlockComment ||
              state == MarkdownHighlighter::CodeBlockTildeComment ||
              state >= MarkdownHighlighter::CodeCpp;
    }
-   static inline bool isCodeBlockEnd(const int state) {
+   static constexpr inline bool isCodeBlockEnd(const int state) {
        return state == MarkdownHighlighter::CodeBlockEnd ||
               state == MarkdownHighlighter::CodeBlockTildeEnd;
    }
@@ -235,6 +235,14 @@ protected:
     void highlightCommentBlock(const QString &text);
 
     void highlightThematicBreak(const QString &text);
+
+    void highlightLists(const QString &text);
+
+//    void highlightOrdereredList();
+
+//    void highlightUnOrdereredList();
+
+//    void highlightCheckedList();
 
     /******************************
      *  INLINE FUNCTIONS

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -241,6 +241,10 @@ protected:
 
     Q_REQUIRED_RESULT int highlightInlineComment(const QString &text, int pos);
 
+    void setHeadingStyles(MarkdownHighlighter::HighlighterState rule,
+                     const QRegularExpressionMatch &match,
+                     const int capturedGroup);
+
     /******************************
      *  CODE HIGHLIGHTING FUNCTIONS
      ******************************/
@@ -271,10 +275,6 @@ protected:
 
     void reHighlightDirtyBlocks();
 
-    void setHeadingStyles(MarkdownHighlighter::HighlighterState rule,
-                     const QRegularExpressionMatch &match,
-                     const int capturedGroup);
-
     QVector<HighlightingRule> _highlightingRules;
     static QHash<HighlighterState, QTextCharFormat> _formats;
     static QHash<QString, HighlighterState> _langStringToEnum;
@@ -283,6 +283,4 @@ protected:
     bool _highlightingFinished;
     HighlightingOptions _highlightingOptions;
     static constexpr int tildeOffset = 300;
-
-    void setCurrentBlockMargin(HighlighterState state);
 };

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -194,16 +194,7 @@ protected:
         HighlightingRule() = default;
 
         QRegularExpression pattern;
-        /*
-         * waqar144:
-         * Dear programmer,
-         * shouldContain[3] is an array of 3 and it may seem that if we don't use an array here
-         * but a simple string (since most of the rules have only one check), it will be faster.
-         * It won't be faster. It will be slower.
-         * The resulting struct is larger in size - 40, as opposed to 24 with a single string.
-         * Dated: 5-Jan-2020
-         */
-        QString shouldContain[3];
+        QString shouldContain;
         HighlighterState state = NoState;
         uint8_t capturingGroup = 0;
         uint8_t maskedGroup = 0;
@@ -238,23 +229,17 @@ protected:
 
     void highlightLists(const QString &text);
 
-//    void highlightOrdereredList();
-
-//    void highlightUnOrdereredList();
-
-//    void highlightCheckedList();
-
     /******************************
      *  INLINE FUNCTIONS
      ******************************/
 
     void highlightInlineRules(const QString &text);
 
-    int highlightInlineSpans(const QString &text, int currentPos, const QChar c);
+    Q_REQUIRED_RESULT int highlightInlineSpans(const QString &text, int currentPos, const QChar c);
 
     void highlightEmAndStrong(const QString &text, const int pos);
 
-    int highlightInlineComment(const QString &text, int pos);
+    Q_REQUIRED_RESULT int highlightInlineComment(const QString &text, int pos);
 
     /******************************
      *  CODE HIGHLIGHTING FUNCTIONS
@@ -268,9 +253,9 @@ protected:
 
     void highlightSyntax(const QString &text);
 
-    int highlightNumericLiterals(const QString& text, int i);
+    Q_REQUIRED_RESULT int highlightNumericLiterals(const QString& text, int i);
 
-    int highlightStringLiterals(QChar strType, const QString& text, int i);
+    Q_REQUIRED_RESULT int highlightStringLiterals(QChar strType, const QString& text, int i);
 
     void ymlHighlighter(const QString &text);
 

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -1196,9 +1196,10 @@ bool QMarkdownTextEdit::handleReturnEntered() {
 
     // if return is pressed and there is just an ordered list symbol then we want to
     // remove the list symbol
-    regex = QRegularExpression(R"(^(\s*)(\d+\.)(\s+)$)");
+    regex = QRegularExpression(R"(^(\s*)(\d+[\.|\)])(\s+)$)");
     iterator = regex.globalMatch(currentLineText);
     if (iterator.hasNext()) {
+        qDebug () << cursor.selectedText();
         cursor.removeSelectedText();
         return true;
     }
@@ -1241,17 +1242,18 @@ bool QMarkdownTextEdit::handleReturnEntered() {
     }
 
     // check for ordered lists and increment the list number in the next line
-    regex = QRegularExpression(R"(^(\s*)(\d+)\.(\s+))");
+    regex = QRegularExpression(R"(^(\s*)(\d+)([\.|\)])(\s+))");
     iterator = regex.globalMatch(currentLineText);
     if (iterator.hasNext()) {
         QRegularExpressionMatch match = iterator.next();
         QString whitespaces = match.captured(1);
         uint listNumber = match.captured(2).toUInt();
-        QString whitespaceCharacter = match.captured(3);
+        QString listMarker = match.captured(3);
+        QString whitespaceCharacter = match.captured(4);
 
         cursor.setPosition(position);
         cursor.insertText("\n" + whitespaces + QString::number(listNumber + 1) +
-        "." + whitespaceCharacter);
+        listMarker + whitespaceCharacter);
 
         // scroll to the cursor if we are at the bottom of the document
         ensureCursorVisible();


### PR DESCRIPTION
- Markdown lists(ordered/unordered/checked/unchecked) have been completely re-written.
  - List parsing is much faster now
  - Ordered lists can optionally have `)` instead of `.` as the char after number. QMarkdownTextedit will complete both these lists on 'Enter' key press
- `_highlightingRulesPre` and `_highlightingRulesAfter` have been merged into one `QVector`.
- Lots of other tiny improvements

`HighlighterRule` struct contains these two fields which don't seem to be used anywhere:
```cpp
        bool useStateAsCurrentBlockState = false;
        bool disableIfCurrentStateIsSet = false;
```
Should I remove them as well?

pbek/QOwnNotes#1598