### PR TITLE
QMarkdownTextedit editor improvements

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -645,10 +645,13 @@ void MarkdownHighlighter::highlightIndentedCodeBlock(const QString &text) {
          && (previousBlockState() < H1 || previousBlockState() > H6) && previousBlockState() != HeadlineEnd)
         return;
 
+    const QString &trimmed = text.trimmed();
+
     //should not be in a list
-    if (text.trimmed().startsWith(QLatin1String("- ")) ||
-            text.trimmed().startsWith(QLatin1String("+ ")) ||
-            text.trimmed().startsWith(QLatin1String("* ")))
+    if (trimmed.startsWith(QLatin1String("- ")) ||
+            trimmed.startsWith(QLatin1String("+ ")) ||
+            trimmed.startsWith(QLatin1String("* ")) ||
+            (trimmed.length() >= 1 && trimmed.at(0).isNumber()))
         return;
 
     setCurrentBlockState(CodeBlockIndented);
@@ -1725,7 +1728,7 @@ void MarkdownHighlighter::highlightLists(const QString &text)
         return;
     }
 
-    /* Orderered List */
+    /* Ordered List */
     if (text.at(spaces).isNumber()) {
         int number = spaces;
         while (number < text.length() && text.at(number).isNumber())
@@ -1765,7 +1768,7 @@ void MarkdownHighlighter::highlightLists(const QString &text)
         }
     }
 
-    /* Unorderered List */
+    /* Unordered List */
     setCurrentBlockState(List);
     setFormat(spaces, 1, _formats[List]);
 }

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -33,9 +33,8 @@
 #include <QClipboard>
 #include <utility>
 
-static Q_DECL_CONSTEXPR std::array<char, 9> _openingCharacters{'(', '[', '{', '<', '*', '"', '\'', '_', '~'};
-static Q_DECL_CONSTEXPR std::array<char, 9> _closingCharacters{')', ']', '}', '>', '*', '"', '\'', '_', '~'};
-
+static const QByteArray _openingCharacters = QByteArrayLiteral("([{<*\"'_~");
+static const QByteArray _closingCharacters = QByteArrayLiteral(")]}>*\"'_~");
 
 QMarkdownTextEdit::QMarkdownTextEdit(QWidget *parent, bool initHighlighter)
         : QPlainTextEdit(parent) {
@@ -762,24 +761,21 @@ bool QMarkdownTextEdit::handleBracketRemoval() {
     // get the current text from the block
     const QString text = cursor.block().text();
 
-    int characterIndex = -1;
-    char charToRemove;
+    char charToRemove{};
 
     //current char
     const char charInFront = text.at(positionInBlock - 1).toLatin1();
     //is it opener?
-    auto it = std::find(_openingCharacters.cbegin(), _openingCharacters.cend(), charInFront);
-    const bool isOpener = it == _openingCharacters.cend() ? false : true;
+    int pos = _openingCharacters.indexOf(charInFront);
+    const bool isOpener = pos == -1 ? false : true;
     if (isOpener) {
-        characterIndex = it - _openingCharacters.cbegin();
-        charToRemove = _closingCharacters.at(characterIndex);
+        charToRemove = _closingCharacters.at(pos);
     } else {
         //is it closer?
-        auto it = std::find(_closingCharacters.cbegin(), _closingCharacters.cend(), charInFront);
-        const bool isCloser = it == _closingCharacters.cend() ? false : true;
+        pos = _closingCharacters.indexOf(charInFront);
+        const bool isCloser = pos == -1 ? false : true;
         if (isCloser) {
-            characterIndex = it - _closingCharacters.cbegin();
-            charToRemove = _openingCharacters.at(characterIndex);
+            charToRemove = _openingCharacters.at(pos);
         } else {
             return false;
         }

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -184,7 +184,7 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
         } else if (keyEvent->modifiers().testFlag(Qt::AltModifier) &&
                     keyEvent->key() == Qt::Key_ParenLeft) {
             // bracket closing for US keyboard on macOS
-            return handleBracketClosing(QStringLiteral("{"), QStringLiteral("}"));
+            return handleBracketClosing(QLatin1Char('{'), QLatin1Char('}'));
 #endif
         } else if (keyEvent->key() == Qt::Key_ParenLeft) {
             return handleBracketClosing(QLatin1Char('('), QLatin1Char(')'));

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -54,7 +54,7 @@ QMarkdownTextEdit::QMarkdownTextEdit(QWidget *parent, bool initHighlighter)
     QFont font = this->font();
 
     // set the tab stop to the width of 4 spaces in the editor
-    const int tabStop = 4;
+    constexpr int tabStop = 4;
     QFontMetrics metrics(font);
 
 #if QT_VERSION < QT_VERSION_CHECK(5,11,0)
@@ -113,7 +113,7 @@ void QMarkdownTextEdit::setHighlightingEnabled(bool enabled) {
  */
 void QMarkdownTextEdit::adjustRightMargin() {
     QMargins margins = layout()->contentsMargins();
-    int rightMargin = document()->size().height() >
+    const int rightMargin = document()->size().height() >
                       viewport()->size().height() ? 24 : 0;
     margins.setRight(rightMargin);
     layout()->setContentsMargins(margins);
@@ -836,7 +836,7 @@ bool QMarkdownTextEdit::increaseSelectedTextIndention(bool reverse, const QStrin
         if (reverse) {
             // un-indent text
 
-            QSettings settings;
+//          QSettings settings;
             const int indentSize = indentCharacters == QStringLiteral("\t") ? 4 : indentCharacters.count();
 
             // remove leading \t or spaces in following lines
@@ -871,7 +871,7 @@ bool QMarkdownTextEdit::increaseSelectedTextIndention(bool reverse, const QStrin
         for (int i = 1; i <= indentSize; i++) {
             // if nothing was selected but we want to reverse the indention check
             // if there is a \t in front or after the cursor and remove it if so
-            int position = cursor.position();
+            const int position = cursor.position();
 
             if (!cursor.atStart()) {
                 // get character in front of cursor
@@ -914,21 +914,21 @@ bool QMarkdownTextEdit::increaseSelectedTextIndention(bool reverse, const QStrin
  */
 bool QMarkdownTextEdit::openLinkAtCursorPosition() {
     QTextCursor cursor = this->textCursor();
-    int clickedPosition = cursor.position();
+    const int clickedPosition = cursor.position();
 
     // select the text in the clicked block and find out on
     // which position we clicked
     cursor.movePosition(QTextCursor::StartOfBlock);
-    int positionFromStart = clickedPosition - cursor.position();
+    const int positionFromStart = clickedPosition - cursor.position();
     cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
 
-    QString selectedText = cursor.selectedText();
+    const QString selectedText = cursor.selectedText();
 
     // find out which url in the selected text was clicked
-    QString urlString = getMarkdownUrlAtPosition(selectedText,
+    const QString urlString = getMarkdownUrlAtPosition(selectedText,
                                                  positionFromStart);
-    QUrl url = QUrl(urlString);
-    bool isRelativeFileUrl = urlString.startsWith(QLatin1String("file://.."));
+    const QUrl url = QUrl(urlString);
+    const bool isRelativeFileUrl = urlString.startsWith(QLatin1String("file://.."));
 
     qDebug() << __func__ << " - 'emit urlClicked( urlString )': "
              << urlString;
@@ -956,7 +956,7 @@ bool QMarkdownTextEdit::openLinkAtCursorPosition() {
  * @return
  */
 bool QMarkdownTextEdit::isValidUrl(const QString& urlString) {
-    QRegularExpressionMatch match =
+    const QRegularExpressionMatch match =
             QRegularExpression(R"(^\w+:\/\/.+)").match(urlString);
     return match.hasMatch();
 }
@@ -1082,19 +1082,17 @@ QString QMarkdownTextEdit::getMarkdownUrlAtPosition(
     QString url;
 
     // get a map of parsed markdown urls with their link texts as key
-    QMap<QString, QString> urlMap = parseMarkdownUrlsFromText(text);
+    const QMap<QString, QString> urlMap = parseMarkdownUrlsFromText(text);
+    QMap<QString,QString>::const_iterator i = urlMap.constBegin();
+    for (; i != urlMap.constEnd(); ++i) {
+        const QString linkText = i.key();
+        const QString urlString = i.value();
 
-    QMapIterator<QString, QString> iterator(urlMap);
-    while (iterator.hasNext()) {
-        iterator.next();
-        QString linkText = iterator.key();
-        QString urlString = iterator.value();
-
-        int foundPositionStart = text.indexOf(linkText);
+        const int foundPositionStart = text.indexOf(linkText);
 
         if (foundPositionStart >= 0) {
             // calculate end position of found linkText
-            int foundPositionEnd = foundPositionStart + linkText.size();
+            const int foundPositionEnd = foundPositionStart + linkText.size();
 
             // check if position is in found string range
             if ((position >= foundPositionStart) &&
@@ -1117,13 +1115,13 @@ void QMarkdownTextEdit::duplicateText() {
 
     // duplicate line if no text was selected
     if (selectedText.isEmpty()) {
-        int position = cursor.position();
+        const int position = cursor.position();
 
         // select the whole line
         cursor.movePosition(QTextCursor::StartOfLine);
         cursor.movePosition(QTextCursor::EndOfLine, QTextCursor::KeepAnchor);
 
-        int positionDiff = cursor.position() - position;
+        const int positionDiff = cursor.position() - position;
         selectedText = "\n" + cursor.selectedText();
 
         // insert text with new line at end of the selected line
@@ -1135,11 +1133,11 @@ void QMarkdownTextEdit::duplicateText() {
     } else {
         // duplicate selected text
         cursor.setPosition(cursor.selectionEnd());
-        int selectionStart = cursor.position();
+        const int selectionStart = cursor.position();
 
         // insert selected text
         cursor.insertText(selectedText);
-        int selectionEnd = cursor.position();
+        const int selectionEnd = cursor.position();
 
         // select the inserted text
         cursor.setPosition(selectionStart);
@@ -1202,10 +1200,10 @@ bool QMarkdownTextEdit::handleReturnEntered() {
     }
 
     QTextCursor cursor = this->textCursor();
-    int position = cursor.position();
+    const int position = cursor.position();
 
     cursor.movePosition(QTextCursor::StartOfBlock, QTextCursor::KeepAnchor);
-    QString currentLineText = cursor.selectedText();
+    const QString currentLineText = cursor.selectedText();
 
     // if return is pressed and there is just an unordered list symbol then we want to
     // remove the list symbol
@@ -1231,9 +1229,9 @@ bool QMarkdownTextEdit::handleReturnEntered() {
     // We are in a list when we have '* ', '- ' or '+ ', possibly with preceding
     // whitespace. If e.g. user has entered '**text**' and pressed enter - we
     // don't want do anymore list-stuff.
-    QChar char0 = currentLineText.trimmed()[0];
-    QChar char1 = currentLineText.trimmed()[1];
-    bool inList = ((char0 == QLatin1Char('*') || char0 == QLatin1Char('-') || char0 == QLatin1Char('+')) && char1 == QLatin1Char(' '));
+    const QChar char0 = currentLineText.trimmed()[0];
+    const QChar char1 = currentLineText.trimmed()[1];
+    const bool inList = ((char0 == QLatin1Char('*') || char0 == QLatin1Char('-') || char0 == QLatin1Char('+')) && char1 == QLatin1Char(' '));
 
     if (inList) {
         // if the current line starts with a list character (possibly after
@@ -1242,16 +1240,16 @@ bool QMarkdownTextEdit::handleReturnEntered() {
         regex = QRegularExpression(R"(^(\s*)([+|\-|\*] \[(x| |)\]|[+\-\*])(\s+))");
         iterator = regex.globalMatch(currentLineText);
         if (iterator.hasNext()) {
-            QRegularExpressionMatch match = iterator.next();
-            QString whitespaces = match.captured(1);
+            const QRegularExpressionMatch match = iterator.next();
+            const QString whitespaces = match.captured(1);
             QString listCharacter = match.captured(2);
-            QString whitespaceCharacter = match.captured(4);
+            const QString whitespaceCharacter = match.captured(4);
 
             // start new checkbox list item with an unchecked checkbox
             iterator = QRegularExpression(R"(^([+|\-|\*]) \[(x| |)\])").globalMatch(listCharacter);
             if (iterator.hasNext()) {
-                QRegularExpressionMatch match = iterator.next();
-                QString realListCharacter = match.captured(1);
+                const QRegularExpressionMatch match = iterator.next();
+                const QString realListCharacter = match.captured(1);
                 listCharacter = realListCharacter + QStringLiteral(" [ ]");
             }
 
@@ -1268,11 +1266,11 @@ bool QMarkdownTextEdit::handleReturnEntered() {
     regex = QRegularExpression(R"(^(\s*)(\d+)([\.|\)])(\s+))");
     iterator = regex.globalMatch(currentLineText);
     if (iterator.hasNext()) {
-        QRegularExpressionMatch match = iterator.next();
-        QString whitespaces = match.captured(1);
-        uint listNumber = match.captured(2).toUInt();
-        QString listMarker = match.captured(3);
-        QString whitespaceCharacter = match.captured(4);
+        const QRegularExpressionMatch match = iterator.next();
+        const QString whitespaces = match.captured(1);
+        const uint listNumber = match.captured(2).toUInt();
+        const QString listMarker = match.captured(3);
+        const QString whitespaceCharacter = match.captured(4);
 
         cursor.setPosition(position);
         cursor.insertText("\n" + whitespaces + QString::number(listNumber + 1) +
@@ -1287,8 +1285,8 @@ bool QMarkdownTextEdit::handleReturnEntered() {
     regex = QRegularExpression(R"(^(\s+))");
     iterator = regex.globalMatch(currentLineText);
     if (iterator.hasNext()) {
-        QRegularExpressionMatch match = iterator.next();
-        QString whitespaces = match.captured(1);
+        const QRegularExpressionMatch match = iterator.next();
+        const QString whitespaces = match.captured(1);
 
         cursor.setPosition(position);
         cursor.insertText("\n" + whitespaces);

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -604,7 +604,7 @@ bool QMarkdownTextEdit::handleBracketClosing(const QChar openingCharacter,
         // User wants: '**'.
         // Not the start of a list, probably bold text. We autocomplete with
         // extra closingCharacter and cursorSubtract to 'catchup'.
-        else if (text == QLatin1Char('*')) {
+        else if (text == QLatin1String("*")) {
             cursor.insertText(QStringLiteral("*"));
             cursorSubtract = 2;
         }

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -1314,7 +1314,7 @@ bool QMarkdownTextEdit::handleTabEntered(bool reverse, const QString& indentChar
     // only check for lists if we haven't a text selected
     if (cursor.selectedText().isEmpty()) {
         cursor.movePosition(QTextCursor::StartOfLine, QTextCursor::KeepAnchor);
-        QString currentLineText = cursor.selectedText();
+        const QString currentLineText = cursor.selectedText();
 
         // check if we want to indent or un-indent an ordered list
         // Valid listCharacters: '+ ', '-' , '* ', '+ [ ] ', '+ [x] ', '- [ ] ', '- [x] ', '* [ ] ', '* [x] '.
@@ -1324,8 +1324,8 @@ bool QMarkdownTextEdit::handleTabEntered(bool reverse, const QString& indentChar
         if (i.hasNext()) {
             QRegularExpressionMatch match = i.next();
             QString whitespaces = match.captured(1);
-            QString listCharacter = match.captured(2);
-            QString whitespaceCharacter = match.captured(4);
+            const QString listCharacter = match.captured(2);
+            const QString whitespaceCharacter = match.captured(4);
 
             // add or remove one tabulator key
             if (reverse) {
@@ -1340,14 +1340,15 @@ bool QMarkdownTextEdit::handleTabEntered(bool reverse, const QString& indentChar
         }
 
         // check if we want to indent or un-indent an ordered list
-        re = QRegularExpression(R"(^(\s*)(\d+)\.(\s+)$)");
+        re = QRegularExpression(R"(^(\s*)(\d+)([\.|\)])(\s+)$)");
         i = re.globalMatch(currentLineText);
 
         if (i.hasNext()) {
-            QRegularExpressionMatch match = i.next();
+            const QRegularExpressionMatch match = i.next();
             QString whitespaces = match.captured(1);
-            QString listCharacter = match.captured(2);
-            QString whitespaceCharacter = match.captured(3);
+            const QString listCharacter = match.captured(2);
+            const QString listMarker = match.captured(3);
+            const QString whitespaceCharacter = match.captured(4);
 
             // add or remove one tabulator key
             if (reverse) {
@@ -1356,7 +1357,7 @@ bool QMarkdownTextEdit::handleTabEntered(bool reverse, const QString& indentChar
                 whitespaces += indentCharacters;
             }
 
-            cursor.insertText(whitespaces + listCharacter + "." +
+            cursor.insertText(whitespaces + listCharacter + listMarker +
             whitespaceCharacter);
             return true;
         }

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -198,14 +198,14 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
         } else if (keyEvent->modifiers().testFlag(Qt::AltModifier) &&
                    keyEvent->key() == Qt::Key_ParenRight) {
             // bracket closing for US keyboard on macOS
-            return bracketClosingCheck("{", "}");
+            return bracketClosingCheck(QLatin1Char('{'), QLatin1Char('}'));
 #endif
         } else if (keyEvent->key() == Qt::Key_ParenRight) {
-            return bracketClosingCheck(QStringLiteral("("), QStringLiteral(")"));
+            return bracketClosingCheck(QLatin1Char('('), QLatin1Char(')'));
         } else if (keyEvent->key() == Qt::Key_BraceRight) {
-            return bracketClosingCheck(QStringLiteral("{"), QStringLiteral("}"));
+            return bracketClosingCheck(QLatin1Char('{'), QLatin1Char('}'));
         } else if (keyEvent->key() == Qt::Key_BracketRight) {
-            return bracketClosingCheck(QStringLiteral("["), QStringLiteral("]"));
+            return bracketClosingCheck(QLatin1Char('['), QLatin1Char(']'));
         } else if (keyEvent->key() == Qt::Key_Return &&
         keyEvent->modifiers().testFlag(Qt::ShiftModifier)) {
             QTextCursor cursor = this->textCursor();
@@ -640,34 +640,34 @@ bool QMarkdownTextEdit::handleBracketClosing(const QChar openingCharacter,
  * @param closingCharacter
  * @return
  */
-bool QMarkdownTextEdit::bracketClosingCheck(const QString& openingCharacter,
-                                            QString closingCharacter) {
+bool QMarkdownTextEdit::bracketClosingCheck(const QChar openingCharacter,
+                                            QChar closingCharacter) {
     // check if bracket closing or read-only are enabled
     if (!(_autoTextOptions & AutoTextOption::BracketClosing) || isReadOnly()) {
         return false;
     }
 
-    if (closingCharacter.isEmpty()) {
+    if (closingCharacter.isNull()) {
         closingCharacter = openingCharacter;
     }
 
     QTextCursor cursor = textCursor();
-    int positionInBlock = cursor.position() - cursor.block().position();
+    const int positionInBlock = cursor.positionInBlock();
 
     // get the current text from the block
-    QString text = cursor.block().text();
-    int textLength = text.length();
+    const QString text = cursor.block().text();
+    const int textLength = text.length();
 
     // if we are at the end of the line we just want to enter the character
     if (positionInBlock >= textLength) {
         return false;
     }
 
-    QString currentChar = text.at(positionInBlock);
+    const QChar currentChar = text.at(positionInBlock);
 
-    if (closingCharacter == openingCharacter) {
+//    if (closingCharacter == openingCharacter) {
 
-    }
+//    }
 
     qDebug() << __func__ << " - 'currentChar': " << currentChar;
 
@@ -678,9 +678,9 @@ bool QMarkdownTextEdit::bracketClosingCheck(const QString& openingCharacter,
         return false;
     }
 
-    QString leftText = text.left(positionInBlock);
-    int openingCharacterCount = leftText.count(openingCharacter);
-    int closingCharacterCount = leftText.count(closingCharacter);
+    const QStringRef leftText = text.leftRef(positionInBlock);
+    const int openingCharacterCount = leftText.count(openingCharacter);
+    const int closingCharacterCount = leftText.count(closingCharacter);
 
     // if there were enough opening characters just enter the character
     if (openingCharacterCount < (closingCharacterCount + 1)) {

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -166,7 +166,7 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
         } else if (keyEvent->key() == Qt::Key_Asterisk) {
             return handleBracketClosing(QStringLiteral("*"));
         } else if (keyEvent->key() == Qt::Key_QuoteDbl) {
-            return quotationMarkCheck(QStringLiteral("\""));
+            return quotationMarkCheck(QLatin1Char('"'));
             // apostrophe bracket closing is temporary disabled because
             // apostrophes are used in different contexts
 //        } else if (keyEvent->key() == Qt::Key_Apostrophe) {
@@ -177,7 +177,7 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
 //            return handleBracketClosing("_");
         }
         else if (keyEvent->key() == Qt::Key_QuoteLeft) {
-            return quotationMarkCheck(QStringLiteral("`"));
+            return quotationMarkCheck(QLatin1Char('`'));
         } else if (keyEvent->key() == Qt::Key_AsciiTilde) {
             return handleBracketClosing(QStringLiteral("~"));
 #ifdef Q_OS_MAC
@@ -583,13 +583,8 @@ bool QMarkdownTextEdit::handleBracketClosing(const QString& openingCharacter,
         // if not text was selected check if we are inside the text
         int positionInBlock = cursor.position() - cursor.block().position();
 
-        // only allow the closing if the cursor was at the end of a block
-        // we are making a special allowance for openingCharacter == *
-        if ((positionInBlock != text.count()) &&
-            !((openingCharacter == QLatin1String("*")) &&
-              (positionInBlock == (text.count() - 1)))) {
+        if (!text.at(positionInBlock).isSpace())
             return false;
-        }
     }
 
     // Remove whitespace at start of string (e.g. in multilevel-lists).
@@ -704,25 +699,25 @@ bool QMarkdownTextEdit::bracketClosingCheck(const QString& openingCharacter,
  * @param quotationCharacter
  * @return
  */
-bool QMarkdownTextEdit::quotationMarkCheck(const QString& quotationCharacter) {
+bool QMarkdownTextEdit::quotationMarkCheck(const QChar quotationCharacter) {
     // check if bracket closing or read-only are enabled
     if (!(_autoTextOptions & AutoTextOption::BracketClosing) || isReadOnly()) {
         return false;
     }
 
     QTextCursor cursor = textCursor();
-    int positionInBlock = cursor.position() - cursor.block().position();
+    const int positionInBlock = cursor.position() - cursor.block().position();
 
     // get the current text from the block
-    QString text = cursor.block().text();
-    int textLength = text.length();
+    const QString &text = cursor.block().text();
+    const int textLength = text.length();
 
     // if we are at the end of the line we just want to enter the character
     if (positionInBlock >= textLength) {
         return handleBracketClosing(quotationCharacter);
     }
 
-    QString currentChar = text.at(positionInBlock);
+    const QChar currentChar = text.at(positionInBlock);
 
     // if the current character is not the quotation character we just want to
     // enter the character

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -33,8 +33,8 @@
 #include <QClipboard>
 #include <utility>
 
-static constexpr std::array<char, 9> _openingCharacters = {'(', '[', '{', '<', '*', '"', '\'', '_', '~'};
-static constexpr std::array<char, 9> _closingCharacters = {')', ']', '}', '>', '*', '"', '\'', '_', '~'};
+static Q_DECL_CONSTEXPR std::array<char, 9> _openingCharacters{'(', '[', '{', '<', '*', '"', '\'', '_', '~'};
+static Q_DECL_CONSTEXPR std::array<char, 9> _closingCharacters{')', ']', '}', '>', '*', '"', '\'', '_', '~'};
 
 
 QMarkdownTextEdit::QMarkdownTextEdit(QWidget *parent, bool initHighlighter)

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -78,15 +78,15 @@ QMarkdownTextEdit::QMarkdownTextEdit(QWidget *parent, bool initHighlighter)
     _searchWidget = new QPlainTextEditSearchWidget(this);
     this->layout()->addWidget(_searchWidget);
 
-    QObject::connect(this, SIGNAL(textChanged()),
-                     this, SLOT(adjustRightMargin()));
-    QObject::connect(this, SIGNAL(cursorPositionChanged()),
-                     this, SLOT(centerTheCursor()));
+    connect(this, &QPlainTextEdit::textChanged,
+            this, &QMarkdownTextEdit::adjustRightMargin);
+    connect(this, &QPlainTextEdit::cursorPositionChanged,
+            this, &QMarkdownTextEdit::centerTheCursor);
 
     updateSettings();
 
     // workaround for disabled signals up initialization
-    QTimer::singleShot(300, this, SLOT(adjustRightMargin()));
+    QTimer::singleShot(300, this, &QMarkdownTextEdit::adjustRightMargin);
 }
 
 /**
@@ -605,7 +605,6 @@ bool QMarkdownTextEdit::handleBracketClosing(const QChar openingCharacter,
         // Not the start of a list, probably bold text. We autocomplete with
         // extra closingCharacter and cursorSubtract to 'catchup'.
         else if (text == QLatin1Char('*')) {
-            cursor.beginEditBlock();
             cursor.insertText(QStringLiteral("*"));
             cursorSubtract = 2;
         }

--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -85,7 +85,7 @@ protected:
                               QString closingCharacter = QLatin1String(""));
     bool bracketClosingCheck(const QString& openingCharacter,
                              QString closingCharacter);
-    bool quotationMarkCheck(const QString& quotationCharacter);
+    bool quotationMarkCheck(const QChar quotationCharacter);
     void focusOutEvent(QFocusEvent *event);
     void paintEvent(QPaintEvent *e);
 

--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -73,8 +73,6 @@ protected:
     QPlainTextEditSearchWidget *_searchWidget;
     QWidget *_searchFrame;
     AutoTextOptions _autoTextOptions;
-    QStringList _openingCharacters;
-    QStringList _closingCharacters;
     bool _mouseButtonDown = false;
     bool _centerCursor = false;
 

--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -81,8 +81,8 @@ protected:
     bool handleTabEntered(bool reverse, const QString& indentCharacters = QChar('\t'));
     QMap<QString, QString> parseMarkdownUrlsFromText(const QString& text);
     bool handleReturnEntered();
-    bool handleBracketClosing(const QString& openingCharacter,
-                              QString closingCharacter = QLatin1String(""));
+    bool handleBracketClosing(const QChar openingCharacter,
+                              QChar closingCharacter = QChar());
     bool bracketClosingCheck(const QString& openingCharacter,
                              QString closingCharacter);
     bool quotationMarkCheck(const QChar quotationCharacter);
@@ -93,5 +93,5 @@ signals:
     void urlClicked(QString url);
 
 private:
-    bool handleBracketClosingUsed;
+    bool _handleBracketClosingUsed;
 };

--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -83,8 +83,8 @@ protected:
     bool handleReturnEntered();
     bool handleBracketClosing(const QChar openingCharacter,
                               QChar closingCharacter = QChar());
-    bool bracketClosingCheck(const QString& openingCharacter,
-                             QString closingCharacter);
+    bool bracketClosingCheck(const QChar openingCharacter,
+                             QChar closingCharacter);
     bool quotationMarkCheck(const QChar quotationCharacter);
     void focusOutEvent(QFocusEvent *event);
     void paintEvent(QPaintEvent *e);


### PR DESCRIPTION
Various small improvements for the editor
- Automatic closing of chars will now happen even if you are in the middle of the line
- Automatic removal of chars for closing chars e.g "], )" (previously automatic removal only happened if the char was an opening char)
- Use QChar in place of QString as it is more lightweight
- `_openingCharacters` and `_closingCharacters` are now `static constexpr std::array` instead of `QStringList`