### PR TITLE
deleted a deprecated method call

### DIFF
--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -69,7 +69,6 @@ QMarkdownTextEdit::QMarkdownTextEdit(QWidget *parent, bool initHighlighter)
     // add a layout to the widget
     auto *layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
-    layout->setMargin(0);
     layout->addStretch();
     this->setLayout(layout);
 


### PR DESCRIPTION
QLayout::setMargin is deprecated (and provokes a compilation error when included in a project and compiled against a recent Qt version) and redundent in this case since QLayout::setContentsMargins does exactly the same thing