### PR TITLE
Fix highlighting being applied to links

### DIFF
--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -278,6 +278,7 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
     void reHighlightDirtyBlocks();
 
     QVector<HighlightingRule> _highlightingRules;
+    QVector<QPair<int,int>> _linkRanges;
     static QHash<HighlighterState, QTextCharFormat> _formats;
     static QHash<QString, HighlighterState> _langStringToEnum;
     QVector<QTextBlock> _dirtyTextBlocks;


### PR DESCRIPTION
pbek/QOwnNotes#1642

This is hacky at best and I have tried to make it efficient. Links with no markup will still get highlighted.