### PR TITLE
Remove unneeded include guard

### DIFF
--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -22,9 +22,7 @@
 #include <QKeyEvent>
 #include <QLayout>
 #include <QPainter>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
 #include <QPainterPath>
-#endif
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 #include <QRegularExpressionMatchIterator>


### PR DESCRIPTION
QPainterPath is in Qt 4.8 [at least](https://doc.qt.io/archives/qt-4.8/qpainterpath.html).