### PR TITLE
Use ranges for correct autoremoval of md chars

### DIFF
--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -200,6 +200,7 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
         int begin;
         int end;
         RangeType type;
+        InlineRange() = default;
         InlineRange(int begin_, int end_, RangeType type_) :
             begin{begin_}, end{end_}, type{type_}
         {}

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -68,7 +68,13 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
                state == MarkdownHighlighter::CodeBlockTildeEnd;
     }
 
-    bool isPosInCodeSpan(int blockNum, int pos) const;
+    enum class RangeType {
+        CodeSpan,
+        Emphasis
+    };
+
+    QPair<int, int> findPositionInRanges(MarkdownHighlighter::RangeType type, int blockNum, int pos) const;
+    bool isPosInACodeSpan(int blockNumber, int position) const;
 
     // we used some predefined numbers here to be compatible with
     // the peg-markdown parser
@@ -190,6 +196,15 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
         uint8_t capturingGroup = 0;
         uint8_t maskedGroup = 0;
     };
+    struct InlineRange {
+        int begin;
+        int end;
+        RangeType type;
+        InlineRange(int begin_, int end_, RangeType type_) :
+            begin{begin_}, end{end_}, type{type_}
+        {}
+    };
+
 
     void highlightBlock(const QString &text) Q_DECL_OVERRIDE;
 
@@ -269,14 +284,15 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
 
     void reHighlightDirtyBlocks();
 
+    void clearRangesForBlock(int blockNumber, RangeType type);
+
     bool _highlightingFinished;
     HighlightingOptions _highlightingOptions;
     QTimer *_timer;
     QVector<QTextBlock> _dirtyTextBlocks;
     QVector<QPair<int,int>> _linkRanges;
 
-    using CodeSpanRanges = QVector<QPair<int,int>>;
-    QHash<int, CodeSpanRanges> _codeSpanRanges;
+    QHash<int, QVector<InlineRange>> _ranges;
 
     static QVector<HighlightingRule> _highlightingRules;
     static QHash<HighlighterState, QTextCharFormat> _formats;

--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -18,8 +18,7 @@
 #include <QPlainTextEdit>
 
 #include "qplaintexteditsearchwidget.h"
-
-class MarkdownHighlighter;
+#include "markdownhighlighter.h"
 
 class QMarkdownTextEdit : public QPlainTextEdit {
     Q_OBJECT
@@ -63,7 +62,7 @@ class QMarkdownTextEdit : public QPlainTextEdit {
     void adjustRightMargin();
     void hide();
     bool openLinkAtCursorPosition();
-    bool handleBracketRemoval();
+    bool handleBackspaceEntered();
     void centerTheCursor();
     void undo();
     void moveTextUpDown(bool up);
@@ -92,6 +91,7 @@ class QMarkdownTextEdit : public QPlainTextEdit {
     bool quotationMarkCheck(const QChar quotationCharacter);
     void focusOutEvent(QFocusEvent *event);
     void paintEvent(QPaintEvent *e);
+    bool handleCharRemoval(MarkdownHighlighter::RangeType type, int block, int position);
 
    signals:
     void urlClicked(QString url);


### PR DESCRIPTION
#105 

Autoremoval of `*` and `` ` `` should be accurate now.