### PR TITLE
Add support for line-numbers

### DIFF
--- a/linenumberarea.h
+++ b/linenumberarea.h
@@ -1,0 +1,109 @@
+#ifndef LINENUMBERAREA_H
+#define LINENUMBERAREA_H
+
+#include <QWidget>
+#include <QPainter>
+#include <QScrollBar>
+#include <QDebug>
+
+#include "qmarkdowntextedit.h"
+
+class LineNumArea : public QWidget {
+    Q_OBJECT
+
+public:
+    LineNumArea(QMarkdownTextEdit *parent)
+        : QWidget(parent),
+          textEdit(parent)
+    {
+        Q_ASSERT(parent);
+
+        setHidden(true);
+
+        // We always use fixed font to avoid "width" issues
+        setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
+    }
+
+    int lineNumAreaWidth() const
+    {
+        int digits = 2;
+        int max = std::max(1, textEdit->blockCount());
+        while (max >= 10) {
+            max /= 10;
+            ++digits;
+        }
+
+        QFontMetrics fm(font());
+#if QT_VERSION >= 0x050B00
+        int space = 13 + textEdit->fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+#else
+        int space = 13 + textEdit->fontMetrics().width(QLatin1Char('9')) * digits;
+#endif
+
+        return space;
+    }
+
+    bool isLineNumAreaEnabled() const
+    {
+        return enabled;
+    }
+
+    void setLineNumAreaEnabled(bool e)
+    {
+        enabled = e;
+        setHidden(!e);
+    }
+
+    QSize sizeHint() const override
+    {
+        return {lineNumAreaWidth(), 0};
+    }
+
+protected:
+    void paintEvent(QPaintEvent *event) override
+    {
+        QPainter painter(this);
+
+        painter.fillRect(event->rect(), palette().color(QPalette::Active, QPalette::Window));
+
+        auto block = textEdit->firstVisibleBlock();
+        int blockNumber = block.blockNumber();
+        qreal top = textEdit->blockBoundingGeometry(block).translated(textEdit->contentOffset()).top();
+        qreal bottom = top;
+
+        const QPen currentLine = QColor("#eef067");
+        const QPen otherLines = QColor("#a6a6a6");
+        auto normalfont = textEdit->font();
+        painter.setFont(normalfont);
+
+        while (block.isValid() && top <= event->rect().bottom()) {
+            top = bottom;
+            bottom = top + textEdit->blockBoundingRect(block).height();
+            if (block.isVisible() && bottom >= event->rect().top())
+            {
+                QString number = QString::number(blockNumber + 1);
+
+                auto isCurrentLine = textEdit->textCursor().blockNumber() == blockNumber;
+                painter.setPen(isCurrentLine ? currentLine : otherLines);
+
+                painter.drawText(
+                    -5,
+                    top,
+                    sizeHint().width(),
+                    textEdit->fontMetrics().height(),
+                    Qt::AlignRight,
+                    number
+                );
+            }
+
+            block = block.next();
+            ++blockNumber;
+        }
+    }
+
+private:
+    bool enabled = false;
+    QMarkdownTextEdit *textEdit;
+};
+
+#endif // LINENUMBERAREA_H

--- a/qmarkdowntextedit-headers.pri
+++ b/qmarkdowntextedit-headers.pri
@@ -1,6 +1,7 @@
 INCLUDEPATH += $$PWD/
 
 HEADERS += \
+    $$PWD/linenumberarea.h \
     $$PWD/markdownhighlighter.h \
     $$PWD/qmarkdowntextedit.h \
     $$PWD/qownlanguagedata.h \

--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -20,8 +20,12 @@
 #include "qplaintexteditsearchwidget.h"
 #include "markdownhighlighter.h"
 
+class LineNumArea;
+
 class QMarkdownTextEdit : public QPlainTextEdit {
     Q_OBJECT
+
+    friend class LineNumArea;
 
    public:
     enum AutoTextOption {
@@ -66,6 +70,7 @@ class QMarkdownTextEdit : public QPlainTextEdit {
     void centerTheCursor();
     void undo();
     void moveTextUpDown(bool up);
+    void setLineNumberEnabled(bool enabled);
 
    protected:
     MarkdownHighlighter *_highlighter;
@@ -92,6 +97,7 @@ class QMarkdownTextEdit : public QPlainTextEdit {
     void focusOutEvent(QFocusEvent *event);
     void paintEvent(QPaintEvent *e);
     bool handleCharRemoval(MarkdownHighlighter::RangeType type, int block, int position);
+    void resizeEvent(QResizeEvent *event);
 
    Q_SIGNALS:
     void urlClicked(QString url);
@@ -99,5 +105,11 @@ class QMarkdownTextEdit : public QPlainTextEdit {
     void zoomOut();
 
    private:
+    void updateLineNumAreaGeometry();
+    void updateLineNumberArea(const QRect &rect, int dy);
+    Q_SLOT void updateLineNumberAreaWidth(int);
+
+   private:
     bool _handleBracketClosingUsed;
+    LineNumArea *_lineNumArea;
 };


### PR DESCRIPTION
It is disabled by default and uses hard-coded colors for now. Colors can be dealt with later. To enable it, one should call
```cpp
plainTextEdit->setLineNumberEnabled(true);
```