### PR TITLE
Fix inline-code and strikeout highlighting

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -28,6 +28,7 @@
 - markdown highlighting
 - syntax highlighting
 - clickable links with `Ctrl + Click`
+- ~strikedout~ text and `inline code;`
 - block indent with `Tab` and `Shift + Tab`
 - duplicate text with `Ctrl + Alt + Down`
 - searching of text with `Ctrl + F`

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -1899,7 +1899,6 @@ int isInLinkRange(int pos, QVector<QPair<int, int>> &range) {
  */
 void MarkdownHighlighter::highlightInlineRules(const QString &text) {
     bool isEmStrongDone = false;
-    bool inlineSpans = false;
 
     // TODO: Add Links and Images parsing
     for (int i = 0; i < text.length(); ++i) {
@@ -1912,11 +1911,10 @@ void MarkdownHighlighter::highlightInlineRules(const QString &text) {
             }
         }
 
-        if (!inlineSpans && (text.at(i) == QLatin1Char('`') ||
+        if ((text.at(i) == QLatin1Char('`') ||
                              text.at(i) == QLatin1Char('~'))) {
 
             highlightInlineSpans(text, i, text.at(i));
-            inlineSpans = true;
 
         } else if (text.at(i) == QLatin1Char('<') && i + 3 < text.length() &&
                    text.at(i + 1) == QLatin1Char('!') &&


### PR DESCRIPTION
When inline-code and strikeout highlighting are used in a line, one of
the markdown element type is not highlighted at all. This change fixes
this.