### PR TITLE
Rework QPlainEditSearchWidget

### DIFF
--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -337,8 +337,8 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
         } else if (keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter) {
             return handleReturnEntered();
         } else if ((keyEvent->key() == Qt::Key_F3)) {
-            _searchWidget->doSearch(
-                !keyEvent->modifiers().testFlag(Qt::ShiftModifier));
+//            _searchWidget->doSearch(
+//                !keyEvent->modifiers().testFlag(Qt::ShiftModifier));
             return true;
         } else if ((keyEvent->key() == Qt::Key_Z) &&
                    (keyEvent->modifiers().testFlag(Qt::ControlModifier)) &&
@@ -1763,7 +1763,7 @@ void QMarkdownTextEdit::doSearch(
     QString &searchText, QPlainTextEditSearchWidget::SearchMode searchMode) {
     _searchWidget->setSearchText(searchText);
     _searchWidget->setSearchMode(searchMode);
-    _searchWidget->doSearchCount();
+    _searchWidget->triggerSearch();
     _searchWidget->activate(false);
 }
 

--- a/qplaintexteditsearchwidget.h
+++ b/qplaintexteditsearchwidget.h
@@ -18,6 +18,8 @@
 #include <QTimer>
 #include <QWidget>
 
+#include "searchoptions.h"
+
 namespace Ui {
 class QPlainTextEditSearchWidget;
 }
@@ -25,55 +27,60 @@ class QPlainTextEditSearchWidget;
 class QPlainTextEditSearchWidget : public QWidget {
     Q_OBJECT
 
-   public:
+public:
     enum SearchMode { PlainTextMode, WholeWordsMode, RegularExpressionMode };
 
     explicit QPlainTextEditSearchWidget(QPlainTextEdit *parent = nullptr);
-    bool doSearch(bool searchDown = true, bool allowRestartAtTop = true,
-                  bool updateUI = true);
-    void setDarkMode(bool enabled);
     ~QPlainTextEditSearchWidget();
+
     void setSearchText(const QString &searchText);
     void setSearchMode(SearchMode searchMode);
     void setDebounceDelay(uint debounceDelay);
+    void setDarkMode(bool enabled);
     void activate(bool focus);
-    void clearSearchExtraSelections();
-    void updateSearchExtraSelections();
 
-   private:
-    Ui::QPlainTextEditSearchWidget *ui;
-    int _searchResultCount;
-    int _currentSearchResult;
-    QList<QTextEdit::ExtraSelection> _searchExtraSelections;
-    QColor selectionColor;
-    QTimer _debounceTimer;
-    QString _searchTerm;
-    void setSearchExtraSelections() const;
-    void stopDebounce();
-
-   protected:
+protected:
     QPlainTextEdit *_textEdit;
     bool _darkMode;
     bool eventFilter(QObject *obj, QEvent *event);
 
-   public slots:
+private:
+    Ui::QPlainTextEditSearchWidget *_ui;
+
+    QString _searchTermUsedInLatestSearch;
+    SearchDirection _directionUsedInLatestSearch;
+    QList<QTextCursor> _latestSearchResults;
+    int _latestSearchLowestCursorIndex;
+    int _latestSearchSelectionIndex;
+    bool _modeChangedFlag;
+    QColor _selectionColor;
+    QTimer _debounceTimer;
+
+    void performSearch(SearchDirection direction);
+    QList<QTextCursor> doSearch(const SearchOptions &searchOptions);
+    void stepSelectionIndexInCurrentSearch(int stepOffset);
+    void clearSearchExtraSelections();
+    void updateSearchExtraSelections();
+    void stopDebounce();
+
+public slots:
+    void setReplaceMode(bool enabled);
     void activate();
     void deactivate();
+    void activateReplace();
+    void triggerSearch();
     void doSearchDown();
     void doSearchUp();
-    void setReplaceMode(bool enabled);
-    void activateReplace();
-    bool doReplace(bool forAll = false);
+    bool doReplace();
     void doReplaceAll();
     void reset();
-    void doSearchCount();
 
-   protected slots:
-    void searchLineEditTextChanged(const QString &arg1);
-    void performSearch();
+private slots:
+    void invalidateSearch();
+    void searchLineEditTextChanged(const QString &searchTerm);
     void updateSearchCountLabelText();
-    void setSearchSelectionColor(const QColor &color);
-   private slots:
+    void clearSearchCountLabelText();
+
     void on_modeComboBox_currentIndexChanged(int index);
     void on_matchCaseSensitiveButton_toggled(bool checked);
 };

--- a/searchoptions.h
+++ b/searchoptions.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2014-2022 Patrizio Bekerle -- <patrizio@bekerle.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ */
+
+#pragma once
+
+enum class SearchDirection
+{
+    Down,
+    Up
+};
+
+struct SearchOptions
+{
+    SearchDirection searchDirection;
+    bool searchFromTheBeginning;
+    bool wrapSearch;
+    bool findMultiOccurances;
+};


### PR DESCRIPTION
Work in progress.
This should address some performance issues and some minor issues in QPlainEditSearchWidget.
- runs search across the entire document only when required (when the search term is changed and when the QPlainTextEdit is modified and the search is invalidated); otherwise, for the up/down search and replacements, it uses the QTextCursor list fetched in the first search.

Missing / required changes:
- further testing
- could be simplified
- benchmark to compare with previous version
- further improvements by replacing deboucing with asynchronous search
