### PR TITLE
Replace obsolete function(QString::count())

### DIFF
--- a/linenumberarea.h
+++ b/linenumberarea.h
@@ -47,7 +47,6 @@ public:
             ++digits;
         }
 
-        QFontMetrics fm(font());
 #if QT_VERSION >= 0x050B00
         int space = 13 + textEdit->fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
 #else

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -1042,7 +1042,7 @@ bool QMarkdownTextEdit::increaseSelectedTextIndention(
             //          QSettings settings;
             const int indentSize = indentCharacters == QStringLiteral("\t")
                                        ? 4
-                                       : indentCharacters.count();
+                                       : indentCharacters.length();
 
             // remove leading \t or spaces in following lines
             newText = selectedText.replace(
@@ -1081,7 +1081,7 @@ bool QMarkdownTextEdit::increaseSelectedTextIndention(
 
         return true;
     } else if (reverse) {
-        const int indentSize = indentCharacters.count();
+        const int indentSize = indentCharacters.length();
 
         // do the check as often as we have characters to un-indent
         for (int i = 1; i <= indentSize; i++) {


### PR DESCRIPTION
[QString::count()](https://doc-snapshots.qt.io/qt6-6.4/qstring-obsolete.html#count-1) is obsolete in Qt 6.4