### PR TITLE
Fix https://github.com/KDE/clazy/blob/1.11/docs/checks/README-base-class-event.md

### DIFF
--- a/linenumberarea.h
+++ b/linenumberarea.h
@@ -1,10 +1,10 @@
 #ifndef LINENUMBERAREA_H
 #define LINENUMBERAREA_H
 
-#include <QWidget>
+#include <QDebug>
 #include <QPainter>
 #include <QScrollBar>
-#include <QDebug>
+#include <QWidget>
 
 #include "qmarkdowntextedit.h"
 
@@ -31,7 +31,7 @@ public:
     }
 
     void setOtherLineColor(QColor color) {
-        _otherLinesColor = color;
+        _otherLinesColor = std::move(color);
     }
 
     int lineNumAreaWidth() const

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -210,7 +210,7 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
     };
 
 
-    void highlightBlock(const QString &text) Q_DECL_OVERRIDE;
+    void highlightBlock(const QString &text);
 
     static void initTextFormats(int defaultFontSize = 12);
 

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -210,7 +210,7 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
     };
 
 
-    void highlightBlock(const QString &text);
+    void highlightBlock(const QString &text) override;
 
     static void initTextFormats(int defaultFontSize = 12);
 

--- a/qmarkdowntextedit.cpp
+++ b/qmarkdowntextedit.cpp
@@ -20,7 +20,6 @@
 #include <QDir>
 #include <QGuiApplication>
 #include <QKeyEvent>
-#include <QWheelEvent>
 #include <QLayout>
 #include <QPainter>
 #include <QPainterPath>
@@ -31,10 +30,11 @@
 #include <QSettings>
 #include <QTextBlock>
 #include <QTimer>
+#include <QWheelEvent>
 #include <utility>
 
-#include "markdownhighlighter.h"
 #include "linenumberarea.h"
+#include "markdownhighlighter.h"
 
 static const QByteArray _openingCharacters = QByteArrayLiteral("([{<*\"'_~");
 static const QByteArray _closingCharacters = QByteArrayLiteral(")]}>*\"'_~");
@@ -340,7 +340,7 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
                     setTextCursor(cursor);
                 }
             }
-            return false;
+            return QPlainTextEdit::eventFilter(obj, event);
         } else if ((keyEvent->key() == Qt::Key_Up) &&
                    keyEvent->modifiers().testFlag(Qt::NoModifier)) {
             // if you are in the first line and press cursor up the cursor will
@@ -358,7 +358,7 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
                     setTextCursor(cursor);
                 }
             }
-            return false;
+            return QPlainTextEdit::eventFilter(obj, event);
         } else if (keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter) {
             return handleReturnEntered();
         } else if ((keyEvent->key() == Qt::Key_F3)) {
@@ -382,7 +382,7 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
             return true;
         }
 
-        return false;
+        return QPlainTextEdit::eventFilter(obj, event);
     } else if (event->type() == QEvent::KeyRelease) {
         auto *keyEvent = static_cast<QKeyEvent *>(event);
 
@@ -391,7 +391,7 @@ bool QMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
             resetMouseCursor();
         }
 
-        return false;
+        return QPlainTextEdit::eventFilter(obj, event);
     } else if (event->type() == QEvent::MouseButtonRelease) {
         _mouseButtonDown = false;
         auto *mouseEvent = static_cast<QMouseEvent *>(event);
@@ -920,7 +920,7 @@ bool QMarkdownTextEdit::handleBackspaceEntered() {
         if (pos == 5 || pos == 6)
             isCloser = isQuotCloser(positionInBlock - 1, text);
         else
-            isCloser = pos == -1 ? false : true;
+            isCloser = pos != -1;
         if (isCloser)
             charToRemove = _openingCharacters.at(pos);
         else
@@ -1619,7 +1619,7 @@ void QMarkdownTextEdit::setAutoTextOptions(AutoTextOptions options) {
     _autoTextOptions = options;
 }
 
-void QMarkdownTextEdit::updateLineNumberArea(const QRect &rect, int dy)
+void QMarkdownTextEdit::updateLineNumberArea(const QRect rect, int dy)
 {
     if (dy)
         _lineNumArea->scroll(0, dy);

--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -95,7 +95,7 @@ class QMarkdownTextEdit : public QPlainTextEdit {
     QColor _currentLineHighlightColor = QColor();
     uint _debounceDelay = 0;
 
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
     QMargins viewportMargins();
     bool increaseSelectedTextIndention(
         bool reverse, const QString &indentCharacters = QChar('\t'));
@@ -108,10 +108,10 @@ class QMarkdownTextEdit : public QPlainTextEdit {
     bool bracketClosingCheck(const QChar openingCharacter,
                              QChar closingCharacter);
     bool quotationMarkCheck(const QChar quotationCharacter);
-    void focusOutEvent(QFocusEvent *event);
-    void paintEvent(QPaintEvent *e);
+    void focusOutEvent(QFocusEvent *event) override;
+    void paintEvent(QPaintEvent *e) override;
     bool handleCharRemoval(MarkdownHighlighter::RangeType type, int block, int position);
-    void resizeEvent(QResizeEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
     void setLineNumberLeftMarginOffset(int offset);
     int _lineNumberLeftMarginOffset = 0;
     LineNumArea *lineNumberArea()

--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -17,8 +17,8 @@
 #include <QEvent>
 #include <QPlainTextEdit>
 
-#include "qplaintexteditsearchwidget.h"
 #include "markdownhighlighter.h"
+#include "qplaintexteditsearchwidget.h"
 
 class LineNumArea;
 
@@ -64,6 +64,7 @@ class QMarkdownTextEdit : public QPlainTextEdit {
 
     void setHighlightCurrentLine(bool set);
     bool highlightCurrentLine();
+
     void setCurrentLineHighlightColor(const QColor &c);
     QColor currentLineHighlightColor();
 
@@ -125,7 +126,7 @@ class QMarkdownTextEdit : public QPlainTextEdit {
 
    private:
     void updateLineNumAreaGeometry();
-    void updateLineNumberArea(const QRect &rect, int dy);
+    void updateLineNumberArea(const QRect rect, int dy);
     Q_SLOT void updateLineNumberAreaWidth(int);
 
    private:

--- a/qplaintexteditsearchwidget.h
+++ b/qplaintexteditsearchwidget.h
@@ -33,6 +33,7 @@ class QPlainTextEditSearchWidget : public QWidget {
                   bool updateUI = true);
     void setDarkMode(bool enabled);
     ~QPlainTextEditSearchWidget();
+
     void setSearchText(const QString &searchText);
     void setSearchMode(SearchMode searchMode);
     void setDebounceDelay(uint debounceDelay);
@@ -54,7 +55,7 @@ class QPlainTextEditSearchWidget : public QWidget {
    protected:
     QPlainTextEdit *_textEdit;
     bool _darkMode;
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
    public Q_SLOTS:
     void activate();


### PR DESCRIPTION
I also sorted the includes and removed `Q_DECL_OVERRIDE` as it is deprecated and also not used in `qmarkdowntextedt.h` to override the events.
