### PR TITLE
Fixed override of font family for bold and italic formatting

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -2310,10 +2310,12 @@ void MarkdownHighlighter::highlightEmAndStrong(const QString &text,
                                    startDelim.marker == QLatin1Char('_');
             while (k != (startDelim.pos + boldLen)) {
                 QTextCharFormat fmt = QSyntaxHighlighter::format(k);
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
                 fmt.setFontFamily(_formats[Bold].fontFamily());
 #else
-                fmt.setFontFamilies(_formats[Bold].fontFamilies().toStringList());
+                const QStringList fontFamilies = _formats[Bold].fontFamilies().toStringList();
+                if (!fontFamilies.isEmpty())
+                    fmt.setFontFamilies(fontFamilies);
 #endif
 
                 if (_formats[state].fontPointSize() > 0)
@@ -2358,10 +2360,12 @@ void MarkdownHighlighter::highlightEmAndStrong(const QString &text,
             while (k != (startDelim.pos + itLen)) {
                 QTextCharFormat fmt = QSyntaxHighlighter::format(k);
 
-#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
                 fmt.setFontFamily(_formats[Italic].fontFamily());
 #else
-                fmt.setFontFamilies(_formats[Italic].fontFamilies().toStringList());
+                const QStringList fontFamilies = _formats[Italic].fontFamilies().toStringList();
+                if (!fontFamilies.isEmpty())
+                    fmt.setFontFamilies(fontFamilies);
 #endif
 
                 if (_formats[state].fontPointSize() > 0)


### PR DESCRIPTION
By calling `setFontFamilies` with an empty list, it seems we're setting a flag on the format that the font family has been explicitly set.

This made bold and italic formatting no longer respect the family of the existing text, or in the case of Notes, a custom font configured by the user:

![Screenshot from 2023-03-17 11-42-40](https://user-images.githubusercontent.com/531764/225888533-cfaa1410-302f-49f6-8a23-04f990854250.png)

(See how bold and italic text appears serif, whereas the user setting was sans-serif.)

After the fix:

![image](https://user-images.githubusercontent.com/531764/225888782-2f852e9e-d5bb-42b3-a99f-9e968fc39f65.png)

I've also updated the Qt version check, since `setFontFamilies` is already available since Qt 5.13.