### PR TITLE
Faster link highlighting with more types supported

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -1994,7 +1994,7 @@ int MarkdownHighlighter::highlightLinkOrImage(const QString &text,
 
         // Apply formatting to highlight the link
         formatAndMaskRemaining(startIndex + 1, closingChar - startIndex - 1,
-                               startIndex, closingChar, _formats[Link]);
+                               startIndex, closingChar + 1, _formats[Link]);
 
         return closingChar;
     }

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -1988,7 +1988,8 @@ int MarkdownHighlighter::highlightLinkOrImage(const QString &text,
             text.mid(startIndex + 1, closingChar - startIndex - 1);
 
         // Check if it's a valid link or email
-        if (!isLink(linkContent) && !isValidEmail(linkContent))
+        if (!isLink(linkContent) && !isValidEmail(linkContent) &&
+            !linkContent.contains(QLatin1Char('.')))
             return startIndex;
 
         // Apply formatting to highlight the link

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -1899,11 +1899,7 @@ void MarkdownHighlighter::highlightInlineRules(const QString &text) {
                                        currentChar == QLatin1Char('_'))) {
             highlightEmAndStrong(text, i);
             isEmStrongDone = true;
-        } else if (currentChar == QLatin1Char('[') ||
-                   currentChar == QLatin1Char('<') ||    // <>
-                   currentChar == QLatin1Char('h') ||    // http
-                   currentChar == QLatin1Char('w')       // www
-        ) {
+        } else {
             i = highlightLinkOrImage(text, i);
         }
     }
@@ -1921,7 +1917,7 @@ bool isLink(const QString &text) {
         QLatin1String("spotify:"), QLatin1String("steam:"),
         QLatin1String("bitcoin:"), QLatin1String("magnet:"),
         QLatin1String("ed2k://"),  QLatin1String("news:"),
-        QLatin1String("ssh://")};
+        QLatin1String("ssh://"),   QLatin1String("note://")};
 
     for (const QLatin1String &scheme : supportedSchemes) {
         if (text.startsWith(scheme)) {
@@ -2001,7 +1997,7 @@ int MarkdownHighlighter::highlightLinkOrImage(const QString &text,
         return closingChar;
     }
     // Highlight http and www links
-    else if (startChar == QLatin1Char('h') || startChar == QLatin1Char('w')) {
+    else if (startChar != QLatin1Char('[')) {
         int space = text.indexOf(QLatin1Char(' '), startIndex);
         if (space == -1) space = text.length();
 

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -1968,7 +1968,7 @@ void MarkdownHighlighter::formatAndMaskRemaining(
  * @return The index where processing should continue.
  */
 int MarkdownHighlighter::highlightLinkOrImage(const QString &text,
-                                              qsizetype startIndex) {
+                                              int startIndex) {
     // If the current blockis a heading, don't process further
     if (isHeading(currentBlockState())) return startIndex;
 

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -90,6 +90,9 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
         return state == MarkdownHighlighter::CodeBlockEnd ||
                state == MarkdownHighlighter::CodeBlockTildeEnd;
     }
+    static constexpr inline bool isHeading(const int state) {
+        return state >= H1 && state <= H6;
+    }
 
     enum class RangeType {
         CodeSpan,
@@ -244,6 +247,10 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
 
     void highlightMarkdown(const QString &text);
 
+    void formatAndMaskRemaining(int formatBegin, int formatLength,
+                                int beginningText, int endText,
+                                const QTextCharFormat &format);
+
     /******************************
      *  BLOCK LEVEL FUNCTIONS
      ******************************/
@@ -277,6 +284,8 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
     void highlightEmAndStrong(const QString &text, const int pos);
 
     Q_REQUIRED_RESULT int highlightInlineComment(const QString &text, int pos);
+
+    int highlightLinkOrImage(const QString &text, qsizetype startIndex);
 
     void setHeadingStyles(MarkdownHighlighter::HighlighterState rule,
                           const QRegularExpressionMatch &match,

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -285,7 +285,7 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
 
     Q_REQUIRED_RESULT int highlightInlineComment(const QString &text, int pos);
 
-    int highlightLinkOrImage(const QString &text, qsizetype startIndex);
+    int highlightLinkOrImage(const QString &text, int startIndex);
 
     void setHeadingStyles(MarkdownHighlighter::HighlighterState rule,
                           const QRegularExpressionMatch &match,


### PR DESCRIPTION
1. Faster link highlighting
2. More link types supported
3. Don't highlight HTML tags with a `.` in it (not true anymore, since it wes requested to support files...)
