### PR TITLE
Fix build with `QT_NO_CAST_FROM_ASCII`

### DIFF
--- a/qmarkdowntextedit.h
+++ b/qmarkdowntextedit.h
@@ -102,9 +102,10 @@ class QMarkdownTextEdit : public QPlainTextEdit {
     bool eventFilter(QObject *obj, QEvent *event) override;
     QMargins viewportMargins();
     bool increaseSelectedTextIndention(
-        bool reverse, const QString &indentCharacters = QChar('\t'));
-    bool handleTabEntered(bool reverse,
-                          const QString &indentCharacters = QChar('\t'));
+        bool reverse,
+        const QString &indentCharacters = QChar::fromLatin1('\t'));
+    bool handleTabEntered(bool reverse, const QString &indentCharacters =
+                                            QChar::fromLatin1('\t'));
     QMap<QString, QString> parseMarkdownUrlsFromText(const QString &text);
     bool handleReturnEntered();
     bool handleBracketClosing(const QChar openingCharacter,


### PR DESCRIPTION
Note: This is only for header files (namely `qmarkdowntextedit.h` and `markdownhiglighter.h`)