### PR TITLE
Fix can't find qmarkdowntextedit.pc called in subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ install(TARGETS qmarkdowntextedit
 )
 
 # Add PkgConfig config file
-configure_file(qmarkdowntextedit.pc.in qmarkdowntextedit.pc @ONLY)
+configure_file(qmarkdowntextedit.pc.in ${CMAKE_BINARY_DIR}/qmarkdowntextedit.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/qmarkdowntextedit.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
 
 # Install exe


### PR DESCRIPTION
`configure_file` will generate files in `CMAKE_BINARY_DIR` by default

But if in a `subdirectory` of cmake, the path may be ambiguous, `configure_ file` may generate . pc file in ${CMAKE_BINARY-DIR}/*subdirectoryname*, causing `install` to be unable to find it

```cmake
    add_subdirectory(qmarkdowntextedit)
```

