### PR TITLE
Add TOML highlighting support

### DIFF
--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -1813,7 +1813,7 @@ void MarkdownHighlighter::tomlHighlighter(const QString &text) {
     if (text.isEmpty()) return;
     const auto textLen = text.length();
 
-    bool onlyWhitespaceBeforeHeader = true; 
+    bool onlyWhitespaceBeforeHeader = true;
     int possibleAssignmentPos = text.indexOf(QLatin1Char('='), 0);
     int singleQStringStart = -1;
     int doubleQStringStart = -1;
@@ -1825,21 +1825,24 @@ void MarkdownHighlighter::tomlHighlighter(const QString &text) {
     for (int i = 0; i < textLen; ++i) {
         if (i + 1 > textLen) {
             break;
-        }   
+        }
 
         // track the state of strings
-        // multiline highlighting doesn't quite behave due to clashing handling of " and '
-        // chars, but this accomodates normal " and ' strings, as well as
-        // ones wrapped by either """ or '''
-        if (text[i] == doubleQ){
-            if (i + 2 <= textLen && text[i + 1] == doubleQ && text[i + 2] == doubleQ){
-                if (multiDoubleQStringStart > -1){
+        // multiline highlighting doesn't quite behave due to clashing handling
+        // of " and ' chars, but this accomodates normal " and ' strings, as
+        // well as ones wrapped by either """ or '''
+        if (text[i] == doubleQ) {
+            if (i + 2 <= textLen && text[i + 1] == doubleQ &&
+                text[i + 2] == doubleQ) {
+                if (multiDoubleQStringStart > -1) {
                     multiDoubleQStringStart = -1;
                 } else {
                     multiDoubleQStringStart = i;
-                    int multiDoubleQStringEnd = text.indexOf(QLatin1String("\"\"\""), i + 1);
-                    if (multiDoubleQStringEnd > -1){
-                        setFormat(i, multiDoubleQStringEnd - i, _formats[CodeString]);
+                    int multiDoubleQStringEnd =
+                        text.indexOf(QLatin1String("\"\"\""), i + 1);
+                    if (multiDoubleQStringEnd > -1) {
+                        setFormat(i, multiDoubleQStringEnd - i,
+                                  _formats[CodeString]);
                         i = multiDoubleQStringEnd + 2;
                         multiDoubleQStringEnd = -1;
                         multiDoubleQStringStart = -1;
@@ -1853,15 +1856,18 @@ void MarkdownHighlighter::tomlHighlighter(const QString &text) {
                     doubleQStringStart = i;
                 }
             }
-        } else if (text[i] == singleQ){
-            if (i + 2 <= textLen && text[i + 1] == singleQ && text[i + 2] == singleQ){
-                if (multiSingleQStringStart > -1){
+        } else if (text[i] == singleQ) {
+            if (i + 2 <= textLen && text[i + 1] == singleQ &&
+                text[i + 2] == singleQ) {
+                if (multiSingleQStringStart > -1) {
                     multiSingleQStringStart = -1;
                 } else {
                     multiSingleQStringStart = i;
-                    int multiSingleQStringEnd = text.indexOf(QLatin1String("'''"), i + 1);
-                    if (multiSingleQStringEnd > -1){
-                        setFormat(i, multiSingleQStringEnd - i, _formats[CodeString]);
+                    int multiSingleQStringEnd =
+                        text.indexOf(QLatin1String("'''"), i + 1);
+                    if (multiSingleQStringEnd > -1) {
+                        setFormat(i, multiSingleQStringEnd - i,
+                                  _formats[CodeString]);
                         i = multiSingleQStringEnd + 2;
                         multiSingleQStringEnd = -1;
                         multiSingleQStringStart = -1;
@@ -1877,47 +1883,51 @@ void MarkdownHighlighter::tomlHighlighter(const QString &text) {
             }
         }
 
-        bool inString = doubleQStringStart > -1 || singleQStringStart > -1 
-            || multiSingleQStringStart > -1 || multiDoubleQStringStart > -1;
+        bool inString = doubleQStringStart > -1 || singleQStringStart > -1 ||
+                        multiSingleQStringStart > -1 ||
+                        multiDoubleQStringStart > -1;
 
         // do comment highlighting
-        if (text[i] == QLatin1Char('#') && !inString){
+        if (text[i] == QLatin1Char('#') && !inString) {
             setFormat(i, textLen - i, _formats[CodeComment]);
             return;
         }
 
         // table header (all stuff preceeding must only be whitespace)
-        if (text[i] == QLatin1Char('[') && onlyWhitespaceBeforeHeader){
+        if (text[i] == QLatin1Char('[') && onlyWhitespaceBeforeHeader) {
             int headerEnd = text.indexOf(QLatin1Char(']'), i);
-            if (headerEnd > -1){
+            if (headerEnd > -1) {
                 setFormat(i, headerEnd + 1 - i, _formats[CodeType]);
                 return;
             }
         }
 
         // handle numbers, inf, nan and datetime the same way
-        if (i > possibleAssignmentPos && !inString && (text[i].isNumber() || 
-                text.indexOf(QLatin1String("inf"), i) > 0 || 
-                text.indexOf(QLatin1String("nan"), i) > 0)) {
+        if (i > possibleAssignmentPos && !inString &&
+            (text[i].isNumber() || text.indexOf(QLatin1String("inf"), i) > 0 ||
+             text.indexOf(QLatin1String("nan"), i) > 0)) {
             int nextWhitespace = text.indexOf(QLatin1Char(' '), i);
             int endOfNumber = textLen;
             if (nextWhitespace > -1) {
-                if (text[nextWhitespace - 1] == QLatin1Char(',')) nextWhitespace--;
+                if (text[nextWhitespace - 1] == QLatin1Char(','))
+                    nextWhitespace--;
                 endOfNumber = nextWhitespace;
             }
 
             int highlightStart = i;
             if (i > 0) {
-                if (text[i - 1] == QLatin1Char('-') || text[i - 1] == QLatin1Char('+')){
+                if (text[i - 1] == QLatin1Char('-') ||
+                    text[i - 1] == QLatin1Char('+')) {
                     highlightStart--;
                 }
             }
-            setFormat(highlightStart, endOfNumber - highlightStart, _formats[CodeNumLiteral]);
+            setFormat(highlightStart, endOfNumber - highlightStart,
+                      _formats[CodeNumLiteral]);
             i = endOfNumber;
         }
 
-        if (!text[i].isSpace()){
-           onlyWhitespaceBeforeHeader = false;
+        if (!text[i].isSpace()) {
+            onlyWhitespaceBeforeHeader = false;
         }
     }
 }

--- a/markdownhighlighter.cpp
+++ b/markdownhighlighter.cpp
@@ -949,7 +949,8 @@ void MarkdownHighlighter::highlightSyntax(const QString &text) {
         default:
             setFormat(0, textLen, _formats[CodeBlock]);
             return;
-}
+    }
+
     auto applyCodeFormat =
         [this](int i, const QMultiHash<char, QLatin1String> &data,
                const QString &text, const QTextCharFormat &fmt) -> int {

--- a/markdownhighlighter.h
+++ b/markdownhighlighter.h
@@ -215,6 +215,8 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
         CodeSystemVerilog = 250,
         CodeSystemVerilogComment = 251,
         CodeGDScript = 252,
+        CodeTOML = 254,
+        CodeTOMLString = 255
     };
     Q_ENUM(HighlighterState)
 
@@ -337,6 +339,7 @@ class MarkdownHighlighter : public QSyntaxHighlighter {
 
     void gdscriptHighlighter(const QString &text);
     void sqlHighlighter(const QString &text);
+    void tomlHighlighter(const QString &text);
 
     void addDirtyBlock(const QTextBlock &block);
 

--- a/qownlanguagedata.cpp
+++ b/qownlanguagedata.cpp
@@ -7264,3 +7264,42 @@ void loadGDScriptData(QMultiHash<char, QLatin1String> &types,
     literals = gdscript_literals;
     other = gdscript_other;
 }
+
+/********************************************************/
+/***   TOML DATA  ***************************************/
+/********************************************************/
+static bool TOMLDataInitialized = false;
+static QMultiHash<char, QLatin1String> TOML_keywords;
+static QMultiHash<char, QLatin1String> TOML_types;
+static QMultiHash<char, QLatin1String> TOML_literals;
+static QMultiHash<char, QLatin1String> TOML_builtin;
+static QMultiHash<char, QLatin1String> TOML_other;
+void initTOMLData() {
+    TOML_keywords = {};
+    TOML_types = {};
+    TOML_literals = {
+        {('f'), QLatin1String("false")},
+        {('t'), QLatin1String("true")},
+        {('n'), QLatin1String("null")},
+        {('i'), QLatin1String("inf")},
+        {('n'), QLatin1String("nan")},
+    };
+
+    TOML_builtin = {};
+    TOML_other = {};
+}
+void loadTOMLData(QMultiHash<char, QLatin1String> &types,
+                  QMultiHash<char, QLatin1String> &keywords,
+                  QMultiHash<char, QLatin1String> &builtin,
+                  QMultiHash<char, QLatin1String> &literals,
+                  QMultiHash<char, QLatin1String> &other) {
+    if (!TOMLDataInitialized) {
+        initTOMLData();
+        TOMLDataInitialized = true;
+    }
+    types = TOML_types;
+    keywords = TOML_keywords;
+    builtin = TOML_builtin;
+    literals = TOML_literals;
+    other = TOML_other;
+}

--- a/qownlanguagedata.h
+++ b/qownlanguagedata.h
@@ -259,4 +259,12 @@ void loadGDScriptData(QMultiHash<char, QLatin1String> &types,
                       QMultiHash<char, QLatin1String> &builtin,
                       QMultiHash<char, QLatin1String> &literals,
                       QMultiHash<char, QLatin1String> &other);
+/********************************************************/
+/***   TOML DATA  **************************************/
+/********************************************************/
+void loadTOMLData(QMultiHash<char, QLatin1String> &types,
+                  QMultiHash<char, QLatin1String> &keywords,
+                  QMultiHash<char, QLatin1String> &builtin,
+                  QMultiHash<char, QLatin1String> &literals,
+                  QMultiHash<char, QLatin1String> &other);
 #endif


### PR DESCRIPTION
Tried my best to add TOML support. Everything is there except for multiline string handling, i.e

```toml
bigString = """
this is a multi
line string
"""
```

After some investigation and experimentation, it seems that when doing multiple `'''` or `"""` while also switching between two block states, it will just fail silently (at least I couldn't find where it stopped trying to render). The `highlightStringLiteral` function seems to clash but even disabling that in `TOML` mode, I sill encountered this issue.
